### PR TITLE
Adding new method in libpluto (pluto_parallel_schedule_with_remapping)

### DIFF
--- a/include/pluto/libpluto.h
+++ b/include/pluto/libpluto.h
@@ -178,6 +178,11 @@ int pluto_schedule_osl(osl_scop_p scop,
 }
 #endif
 
+/*
+ * Structure to hold Remapping information
+ * Consists of number of statements, Remapping pluto matrix
+ * and divs.
+ */
 struct remapping {
     int nstmts;
     PlutoMatrix **stmt_inv_matrices;

--- a/include/pluto/libpluto.h
+++ b/include/pluto/libpluto.h
@@ -178,6 +178,12 @@ int pluto_schedule_osl(osl_scop_p scop,
 }
 #endif
 
+struct remapping {
+    int nstmts;
+    PlutoMatrix **stmt_inv_matrices;
+    int **stmt_divs;
+};
+typedef struct remapping Remapping;
 
 /*
 This function is a HACK. The reason this exists is to allow for easy FFI
@@ -192,16 +198,9 @@ isl object.
 void pluto_schedule_str(const char *domains_str,
         const char *dependences_str,
         char** schedules_str_buffer_ptr,
+        char** p_loops,
+        Remapping **remapping_ptr,
         PlutoOptions *options);
-
-
-
-struct remapping {
-    int nstmts;
-    PlutoMatrix **stmt_inv_matrices;
-    int **stmt_divs;
-};
-typedef struct remapping Remapping;
 
 void pluto_remapping_free(Remapping *);
 

--- a/src/libpluto.c
+++ b/src/libpluto.c
@@ -375,7 +375,6 @@ __isl_give isl_union_map *pluto_schedule(isl_union_set *domains,
     return schedules;
 }
 
-
 Remapping *pluto_get_remapping(isl_union_set *domains,
         isl_union_map *dependences, PlutoOptions *options_l) 
 {
@@ -488,7 +487,6 @@ Remapping *pluto_get_remapping(isl_union_set *domains,
          remapping->stmt_inv_matrices[i] = pluto_stmt_get_remapping(prog->stmts[i],
                 &remapping->stmt_divs[i]);
     }
-
     return remapping;
 }
 
@@ -625,17 +623,247 @@ int pluto_schedule_osl(osl_scop_p scop,
   return EXIT_SUCCESS;
 }
 
+/* Pluto_schedule method to get schedule, parallel loops and remapping
+*  all in one function
+*/
+__isl_give isl_union_map *pluto_parallel_schedule_with_remapping(isl_union_set *domains,
+        isl_union_map *dependences,
+        Ploop*** ploops,
+        int* nploops,
+        Remapping** remap,
+        PlutoOptions *options_l)
+{
+    int i, j, nbands, n_ibands, retval;
+    isl_ctx *ctx;
+    isl_space *space;
+    double t_t, t_all, t_start;
+
+    ctx = isl_union_set_get_ctx(domains);
+    space = isl_union_set_get_space(domains);
+
+    PlutoProg *prog = pluto_prog_alloc();
+    prog->options = options_l;
+
+    /* global var */
+    options = options_l;
+
+
+    prog->nvar = -1;
+    prog->nstmts = isl_union_set_n_set(domains);
+
+    if (prog->nstmts >= 1) {
+        prog->stmts = (Stmt **)malloc(prog->nstmts * sizeof(Stmt *));
+    }else{
+        prog->stmts = NULL;
+    }
+
+    for (i=0; i<prog->nstmts; i++) {
+        prog->stmts[i] = NULL;
+    }
+
+    extract_stmts(domains, prog->stmts);
+
+    for (i=0; i<prog->nstmts; i++) {
+        prog->nvar = PLMAX(prog->nvar, prog->stmts[i]->dim);
+    }
+
+    if (prog->nstmts >= 1) {
+        Stmt *stmt = prog->stmts[0];
+        prog->npar = stmt->domain->ncols - stmt->dim - 1;
+        prog->params = (char **) malloc(sizeof(char *)*prog->npar);
+    }else prog->npar = 0;
+
+    for (i=0; i<prog->npar; i++) {
+        char *param = malloc(5);
+        sprintf(param, "p%d", i);
+        prog->params[i] = param;
+    }
+
+    prog->ndeps = 0;
+    isl_union_map_foreach_map(dependences, &isl_map_count, &prog->ndeps);
+
+    prog->deps = (Dep **)malloc(prog->ndeps * sizeof(Dep *));
+    for (i=0; i<prog->ndeps; i++) {
+        prog->deps[i] = pluto_dep_alloc();
+    }
+    extract_deps(prog->deps, 0, prog->stmts,
+            dependences, OSL_DEPENDENCE_RAW);
+
+    IF_DEBUG(pluto_prog_print(stdout, prog););
+
+    t_start = rtclock();
+    retval = pluto_auto_transform(prog);
+    t_t = rtclock() - t_start;
+
+    if (retval) {
+        /* Failure */
+        pluto_prog_free(prog);
+        isl_space_free(space);
+
+        if (!options->silent) {
+            printf("[libpluto] failure, returning NULL schedules\n");
+        }
+
+        return NULL;
+    }
+
+    pluto_compute_dep_directions(prog);
+    pluto_compute_dep_satisfaction(prog);
+
+    if (!options->silent) {
+        fprintf(stdout, "[pluto] Affine transformations\n\n");
+        /* Print out transformations */
+        pluto_transformations_pretty_print(prog);
+    }
+
+    Band **bands, **ibands;
+    bands = pluto_get_outermost_permutable_bands(prog, &nbands);
+    ibands = pluto_get_innermost_permutable_bands(prog, &n_ibands);
+    printf("Outermost tilable bands: %d bands\n", nbands);
+    pluto_bands_print(bands, nbands);
+    printf("Innermost tilable bands: %d bands\n", n_ibands);
+    pluto_bands_print(ibands, n_ibands);
+
+    if (options->tile) {
+        pluto_tile(prog);
+    }else{
+        if (options->intratileopt) {
+            pluto_intra_tile_optimize(prog, 0);
+        }
+    }
+
+    if ((options->parallel) && !options->tile && !options->identity)   {
+        /* Obtain wavefront/pipelined parallelization by skewing if
+         * necessary */
+        int nbands;
+        Band **bands;
+        pluto_compute_dep_satisfaction(prog);
+        bands = pluto_get_outermost_permutable_bands(prog, &nbands);
+        bool retval = pluto_create_tile_schedule(prog, bands, nbands);
+        pluto_bands_free(bands, nbands);
+
+        /* If the user hasn't supplied --tile and there is only pipelined
+         * parallelism, we will warn the user */
+        if (retval)   {
+            printf("[pluto] WARNING: pipelined parallelism exists and --tile is not used.\n");
+            printf("[pluto] WARNING: use --tile for better parallelization \n");
+            fprintf(stdout, "[pluto] After skewing:\n");
+            pluto_transformations_pretty_print(prog);
+            /* IF_DEBUG(pluto_print_hyperplane_properties(prog);); */
+        }
+    }
+
+    if (options->parallel && !options->silent) {
+        *ploops = pluto_get_parallel_loops(prog, nploops);
+        printf("[pluto_mark_parallel] %d parallel loops\n", *nploops);
+        pluto_loops_print(*ploops, *nploops);
+        printf("\n");
+    }
+
+    // Constructing remapping Matrix
+    Remapping *remapping = (Remapping *)malloc(sizeof(Remapping));
+    remapping->nstmts = prog->nstmts;
+    remapping->stmt_inv_matrices =
+        (PlutoMatrix **)malloc(sizeof(PlutoMatrix *) * prog->nstmts);
+    remapping->stmt_divs = (int **)malloc(sizeof(int *) * prog->nstmts);
+
+    *remap = remapping;
+
+    for(i = 0; i < prog->nstmts; i++) {
+         printf("Statement %d Id- %d\n",i,prog->stmts[i]->id);
+         remapping->stmt_inv_matrices[i] = pluto_stmt_get_remapping(prog->stmts[i],
+                &remapping->stmt_divs[i]);
+         pluto_matrix_print(stdout, remapping->stmt_inv_matrices[i]);
+    }
+
+    /* Construct isl_union_map for pluto schedules */
+    isl_union_map *schedules = isl_union_map_empty(isl_space_copy(space));
+    for (i=0; i<prog->nstmts; i++) {
+        isl_basic_map *bmap;
+        isl_map *map;
+        Stmt *stmt = prog->stmts[i];
+        PlutoConstraints *sched = normalize_domain_schedule(stmt, prog);
+        // pluto_constraints_print(stdout, sched);
+
+        bmap = isl_basic_map_from_pluto_constraints(ctx, sched,
+                sched->ncols - stmt->trans->nrows - prog->npar - 1,
+                stmt->trans->nrows, prog->npar);
+        bmap = isl_basic_map_project_out(bmap, isl_dim_in, 0, sched->ncols - stmt->trans->nrows - stmt->domain->ncols);
+        char name[20];
+        snprintf(name, sizeof(name), "S_%d", i);
+        map = isl_map_from_basic_map(bmap);
+
+        /* Copy ids of the original parameter dimensions  */
+        for (j=0; j<isl_space_dim(space, isl_dim_param); j++) {
+            isl_id *id = isl_space_get_dim_id(space, isl_dim_param, j);
+            map = isl_map_set_dim_id(map, isl_dim_param, j, id);
+        }
+
+        map = isl_map_set_tuple_name(map, isl_dim_in, name);
+        schedules = isl_union_map_union(schedules, isl_union_map_from_map(map));
+
+        pluto_constraints_free(sched);
+    }
+
+    pluto_prog_free(prog);
+    isl_space_free(space);
+
+    t_all = rtclock() - t_start;
+
+    if (options->time && !options->silent) {
+        printf("[pluto] Auto-transformation time: %0.6lfs\n", t_t);
+        printf("[pluto] Other/Misc time: %0.6lfs\n", t_all-t_t);
+        printf("[pluto] Total time: %0.6lfs\n", t_all);
+    }
+
+    return schedules;
+}
+
+
 void pluto_schedule_str(const char *domains_str,
         const char *dependences_str,
         char** schedules_str_buffer_ptr,
+        char** p_loops,
+        Remapping **remapping_ptr,
         PlutoOptions *options) {
 
     isl_ctx *ctx = isl_ctx_alloc();
+    Ploop** ploop;
+    int nploop,i;
+    Remapping* remapping;
+
     isl_union_set *domains = isl_union_set_read_from_str(ctx, domains_str);
     isl_union_map *dependences = isl_union_map_read_from_str(ctx, 
             dependences_str);
 
-    isl_union_map *schedule = pluto_schedule(domains, dependences, options);
+    assert(remapping_ptr != NULL);
+    isl_union_map *schedule = pluto_parallel_schedule_with_remapping(domains,
+            dependences, &ploop, &nploop, &remapping, options);
+
+    if (options->parallel) {
+       pluto_loops_print(ploop, nploop);
+
+       // NOTE: assuming max 4 digits
+       // number of parallel loops
+       char * str = (char *)(malloc(sizeof(char) * 5));
+       sprintf(str, "%d", nploop);
+
+       // NOTE: assuming max 4 digits per integer, and 1 char for comma
+       // 1 place for 'nploop' int itself, and nploop places for the rest
+       p_loops[0] = (char *) malloc(sizeof(char) * 6 * (nploop+1));
+       strcpy(p_loops[0], str);
+
+       for(i = 1; i < nploop + 1; i++)
+       {
+           // the result is a csv list
+           strcat(p_loops[0], ",");
+           // add the i'th parallel loop dim
+           sprintf(str, "%d", ploop[i-1]->depth+1);
+           strcat(p_loops[0], str);
+       }
+    }
+
+    *remapping_ptr = remapping;
 
     isl_printer *printer = isl_printer_to_str(ctx);
     isl_printer_print_union_map(printer, schedule);
@@ -652,8 +880,6 @@ void pluto_schedule_str(const char *domains_str,
     isl_ctx_free(ctx);
 
 }
-
-
 
 void pluto_get_remapping_str(const char *domains_str,
         const char *dependences_str,

--- a/src/libpluto.c
+++ b/src/libpluto.c
@@ -819,7 +819,11 @@ __isl_give isl_union_map *pluto_parallel_schedule_with_remapping(isl_union_set *
     return schedules;
 }
 
-
+/* pluto_schedule_str is a wrapper method around
+ * pluto_parallel_schedule_with_remapping().
+ * This method accepts domain, dependence and PlutoOptions as string
+ * and returns a transformed schedule, remapping and parallel loops.
+ */
 void pluto_schedule_str(const char *domains_str,
         const char *dependences_str,
         char** schedules_str_buffer_ptr,


### PR DESCRIPTION
Adding new method in libpluto (pluto_parallel_schedule_with_remapping) for returning information about parallel loops and remapping along with transformed schedule. This reduces the number of libpluto calls we make from Polymage.