### PR TITLE
Add test case for consecutive reductions where fusion is possible with delay

### DIFF
--- a/test/fusion11.c
+++ b/test/fusion11.c
@@ -1,0 +1,12 @@
+#pragma scop
+for (int _i0 = 0; (_i0 < (N - 7371)); _i0++) {
+    for (int _i1 = 0; (_i1 <= 7238); _i1++) {
+        yf1[_i0] = (yf1[_i0] + (yds[((7238 + _i0) - _i1)] * taps1[_i1]));
+    }
+}
+for (int _i0 = 0; (_i0 < (N - 14609)); _i0++) {
+    for (int _i1 = 0; (_i1 <= 7238); _i1++) {
+        yf2[_i0] = (yf2[_i0] + (yf1[((7238 + _i0) - _i1)] * taps2[_i1]));
+    }
+}
+#pragma endscop


### PR DESCRIPTION
This is a sub-part of the PolyMage code generated for the vuvuzela app (but is a common pattern in DSP applications in general - corresponding to filtering followed by a delay) with no early frees or storage optimizations. The loop bounds have been changed (N / 5 has been replaced with N). Currently, the loops are not fused. However, fusion would help reduce the total number of iterations and improve locality besides allowing storage optimizations.