### PR TITLE
Add glpk solver support to pluto

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ fi
 glpk="false"
 dnl glpk flag
 AC_ARG_ENABLE(glpk,
-              [ --enable-glpk enable ILP Solving with glpk], glpk="true")
+              [  --enable-glpk  enable ILP solving with GLPK], glpk="true")
 
 dnl check for programs
 AC_CHECK_PROG(CC,gcc,gcc)
@@ -81,11 +81,11 @@ AC_CHECK_PROG(SED,sed,sed)
 
 if test $glpk = "true"; then
     dnl check for glpk
-    AC_CHECK_HEADER([glpk.h],[AC_DEFINE([GLPK],[1],[glpk solver for solving ILP])]
+    AC_CHECK_HEADER([glpk.h],[AC_DEFINE([GLPK],[1],[GLPK solver for solving ILP])]
                                 CFLAGS="$CFLAGS -DGLPK" LDFLAGS="$LDFLAGS -lglpk"
                                 , [AC_ERROR([glpk.h header not found])])
     AC_CHECK_LIB([glpk], [glp_create_prob], []
-                 , [AC_ERROR([glpk library not found])])
+                 , [AC_ERROR([GLPK library not found])])
 fi
 
 dnl Offer --with-gmp-prefix.

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,11 @@ if test $debug = "true"; then
     CFLAGS="$CFLAGS -g"
 fi
 
+glpk="false"
+dnl glpk flag
+AC_ARG_ENABLE(glpk,
+              [ --enable-glpk enable ILP Solving with glpk], glpk="true")
+
 dnl check for programs
 AC_CHECK_PROG(CC,gcc,gcc)
 AC_PROG_CXX
@@ -73,6 +78,15 @@ AC_CHECK_PROG(CAT,cat,cat)
 AC_CHECK_PROG(AR,ar,ar)
 AC_CHECK_PROG(STRIP,strip,strip)
 AC_CHECK_PROG(SED,sed,sed)
+
+if test $glpk = "true"; then
+    dnl check for glpk
+    AC_CHECK_HEADER([glpk.h],[AC_DEFINE([GLPK],[1],[glpk solver for solving ILP])]
+                                CFLAGS="$CFLAGS -DGLPK" LDFLAGS="$LDFLAGS -lglpk"
+                                , [AC_ERROR([glpk.h header not found])])
+    AC_CHECK_LIB([glpk], [glp_create_prob], []
+                 , [AC_ERROR([glpk library not found])])
+fi
 
 dnl Offer --with-gmp-prefix.
 AC_ARG_WITH(gmp-prefix,

--- a/include/pluto/libpluto.h
+++ b/include/pluto/libpluto.h
@@ -154,6 +154,9 @@ struct plutoOptions{
     /* Use isl as ilp solver. */
     int islsolve;
 
+    /* Use glpk as ilp solver. */
+    int glpk;
+
     /* Index set splitting */
     int iss;
 

--- a/src/constraints.c
+++ b/src/constraints.c
@@ -1192,7 +1192,7 @@ void set_glpk_constraints_from_pluto_constraints(glp_prob *lp, const PlutoConstr
 
     nrows = cst->nrows;
     ncols = cst->ncols;
-    non_zero = get_num_non_zero_elements_from_pluto_constraints(cst);
+    non_zero = pluto_constraints_get_num_non_zero_coeffs(cst);
 
     assert (lp != NULL);
 
@@ -2370,10 +2370,10 @@ void pluto_constraints_remove_const_ub(PlutoConstraints *cst, int pos)
 }
 
 /* Returns the number of non-zero elements in the
- * input matrix, excluding the constant term */
-int get_num_non_zero_elements_from_pluto_constraints(const PlutoConstraints* cst)
+ * constraint matrix, excluding the constant term */
+int pluto_constraints_get_num_non_zero_coeffs(const PlutoConstraints* cst)
 {
-    int nrows, ncols, non_zeros,i,j;
+    int nrows, ncols, non_zeros, i, j;
 
     nrows = cst->nrows;
     ncols = cst->ncols;

--- a/src/constraints.c
+++ b/src/constraints.c
@@ -1153,6 +1153,183 @@ int64 *pluto_constraints_lexmin(const PlutoConstraints *cst, int negvar)
     }
 }
 
+#ifdef GLPK
+PlutoMatrix* construct_cplex_objective(const PlutoConstraints *cst, const PlutoProg *prog)
+{
+    int npar = prog->npar;
+    int nvar = prog->nvar;
+    int i, j, k;
+
+    PlutoMatrix *obj = pluto_matrix_alloc(1, cst->ncols-1);
+    pluto_matrix_set(obj, 0);
+
+    /* u */
+    for (j=0; j<npar; j++) {
+        obj->val[0][j] = 5*5*nvar*prog->nstmts;
+    }
+    /* w  */
+    obj->val[0][npar] = 5*nvar*prog->nstmts;
+
+    for (i=0, j=npar+1; i<prog->nstmts; i++) {
+        for (k=j; k<j+prog->stmts[i]->dim_orig; k++) {
+            obj->val[0][k] = (nvar+2)*(prog->stmts[i]->dim_orig-(k-j));
+        }
+        /* constant shift */
+        obj->val[0][k] = 1;
+        j += prog->stmts[i]->dim_orig + 1;
+    }
+    return obj;
+
+}
+
+/* Constructs constraints for glpk problem in-memory.  Assumes that there
+ * are no rows or cols in glp_prob lp.*/
+void set_glpk_constraints_from_pluto_constraints(glp_prob *lp, const PlutoConstraints *cst)
+{
+    int i, j, k, nrows, ncols, non_zero;
+    int *row, *col;
+    double *coeff;
+
+    nrows = cst->nrows;
+    ncols = cst->ncols;
+    non_zero = get_num_non_zero_elements_from_pluto_constraints(cst);
+
+    assert (lp != NULL);
+
+    glp_add_rows(lp,cst->nrows);
+    glp_add_cols(lp,cst->ncols-1);
+
+    /* These are indexed from 1 */
+    row = (int*)malloc((non_zero+1)*sizeof(int));
+    col = (int*)malloc((non_zero+1)*sizeof(int));
+    coeff = (double*)malloc((non_zero+1)*sizeof(double));
+
+    k = 1;
+    for (i=0; i<nrows;i++) {
+        if (cst->is_eq[i]) {
+            /* For equality constraints the bounds are fixed */
+            glp_set_row_bnds(lp, i+1, GLP_FX, -cst->val[i][cst->ncols-1], 0.0);
+        } else {
+            /* Add a lower bound on each row of the inequality */
+            glp_set_row_bnds(lp, i+1, GLP_LO, -cst->val[i][cst->ncols-1], 0.0);
+        }
+
+        for (j=0; j<ncols-1; j++) {
+            if (cst->val[i][j] != 0) {
+                row[k] = i+1;
+                col[k] = j+1;
+                coeff[k] = (double) cst->val[i][j];
+                k++;
+            }
+        }
+    }
+    glp_load_matrix(lp, non_zero, row, col, coeff);
+    free(row);
+    free(col);
+    free(coeff);
+}
+
+int64 *pluto_constraints_solve_glpk(glp_prob *lp, const PlutoConstraints *cst)
+{
+    int j;
+    if (!options->debug && !options->moredebug) {
+        glp_term_out(GLP_OFF);
+    }
+
+    glp_smcp parm;
+    glp_init_smcp(&parm);
+    parm.presolve = GLP_ON;
+
+    parm.msg_lev = GLP_MSG_OFF;
+    IF_DEBUG(parm.msg_lev = GLP_MSG_ON;);
+    IF_MORE_DEBUG(parm.msg_lev = GLP_MSG_ALL;);
+
+
+    glp_scale_prob(lp, GLP_SF_AUTO);
+    glp_adv_basis(lp, 0);
+    glp_simplex(lp, &parm);
+
+    int lp_status = glp_get_status(lp);
+
+    if (lp_status == GLP_INFEAS || lp_status == GLP_UNDEF) {
+        glp_delete_prob(lp);
+        return NULL;
+    }
+
+    glp_iocp iocp;
+    glp_init_iocp(&iocp);
+    /* The default is 1e-5; one may need to reduce it even further
+     * depending on how large a coefficient we might see */
+    iocp.tol_int = 1e-7;
+    IF_DEBUG(printf("Setting GLPK integer tolerance to %e\n", iocp.tol_int));
+
+    iocp.msg_lev = GLP_MSG_OFF;
+    IF_DEBUG(iocp.msg_lev = GLP_MSG_ON;);
+    IF_MORE_DEBUG(iocp.msg_lev = GLP_MSG_ALL;);
+
+    glp_intopt(lp, &iocp);
+
+    int ilp_status = glp_mip_status(lp);
+
+    if (ilp_status == GLP_INFEAS || ilp_status == GLP_UNDEF) {
+        glp_delete_prob(lp);
+        return NULL;
+    }
+
+    double z = glp_mip_obj_val(lp);
+    IF_DEBUG(printf("z = %lf\n", z););
+    int64* sol = malloc(sizeof(int64)*(cst->ncols-1));
+    for (j=0; j<glp_get_num_cols(lp); j++) {
+        double x = glp_mip_col_val(lp, j+1);
+        IF_DEBUG(printf("c%d = %lld, ", j, (int64) round(x)););
+        sol[j] = (int) round(x);
+    }
+    IF_DEBUG(printf("\n"););
+    glp_delete_prob(lp);
+    return sol;
+}
+
+/* Construct ILP in cplex format */
+int64 *pluto_prog_constraints_lexmin_glpk(const PlutoConstraints *cst,
+        PlutoProg *prog)
+{
+    int i, j;
+    PlutoMatrix *obj;
+    int64 *sol;
+
+
+    IF_DEBUG(printf("[pluto] pluto_prog_constraints_lexmin_glpk (%d variables, %d constraints)\n",
+                cst->ncols-1, cst->nrows););
+
+    glp_prob *lp;
+    lp = glp_create_prob();
+
+    glp_set_obj_dir(lp, GLP_MIN);
+
+    obj = construct_cplex_objective(cst, prog);
+
+    set_glpk_constraints_from_pluto_constraints(lp, cst);
+
+    for (j=0; j<obj->ncols; j++) {
+        glp_set_obj_coef(lp, j+1, (double)obj->val[0][j]);
+    }
+    pluto_matrix_free(obj);
+
+    for (i=0; i<cst->ncols-1; i++) {
+        glp_set_col_bnds(lp, i+1, GLP_FR, 0.0, 0.0);
+    }
+    for (i=0; i<cst->ncols-1; i++) {
+        glp_set_col_kind(lp, i+1, GLP_IV);
+    }
+    IF_DEBUG(glp_write_lp(lp, NULL, "pluto-debug-glpk.lp"););
+
+
+    sol = pluto_constraints_solve_glpk(lp, cst);
+
+    return sol;
+}
+
+#endif
 
 /* All equalities */
 PlutoConstraints *pluto_constraints_from_equalities(const PlutoMatrix *mat)
@@ -2190,6 +2367,26 @@ void pluto_constraints_remove_const_ub(PlutoConstraints *cst, int pos)
             }else i++;
         }
     }
+}
+
+/* Returns the number of non-zero elements in the
+ * input matrix, excluding the constant term */
+int get_num_non_zero_elements_from_pluto_constraints(const PlutoConstraints* cst)
+{
+    int nrows, ncols, non_zeros,i,j;
+
+    nrows = cst->nrows;
+    ncols = cst->ncols;
+    non_zeros = 0;
+
+    for (i=0; i<nrows; i++) {
+        for (j=0; j<ncols-1; j++) {
+            if (cst->val[i][j] != 0) {
+                non_zeros++;
+            }
+        }
+    }
+    return non_zeros;
 }
 
 /*

--- a/src/constraints.h
+++ b/src/constraints.h
@@ -197,6 +197,5 @@ void pluto_constraints_cplex_print(FILE *fp, const PlutoConstraints *cst);
 PlutoConstraints *farkas_lemma_affine(const PlutoConstraints *dom, const PlutoMatrix *phi);
 void pluto_constraints_gaussian_eliminate(PlutoConstraints *cst, int pos);
 
-int get_num_non_zero_elements_from_pluto_constraints(const PlutoConstraints* cst);
-
+int pluto_constraints_get_num_non_zero_coeffs(const PlutoConstraints* cst);
 #endif

--- a/src/constraints.h
+++ b/src/constraints.h
@@ -20,6 +20,10 @@
 #ifndef _CONSTRAINTS_H
 #define _CONSTRAINTS_H
 
+#ifdef GLPK
+#include <glpk.h>
+#endif
+
 #include "isl/set.h"
 #include "math_support.h"
 
@@ -192,5 +196,7 @@ void pluto_constraints_remove_names_single(PlutoConstraints *cst);
 void pluto_constraints_cplex_print(FILE *fp, const PlutoConstraints *cst);
 PlutoConstraints *farkas_lemma_affine(const PlutoConstraints *dom, const PlutoMatrix *phi);
 void pluto_constraints_gaussian_eliminate(PlutoConstraints *cst, int pos);
+
+int get_num_non_zero_elements_from_pluto_constraints(const PlutoConstraints* cst);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,9 @@ void usage_message(void)
     fprintf(stdout, "                                 (disabled by default)\n");
     fprintf(stdout, "       --islsolve [default]      Use ISL as ILP solver (default)\n");
     fprintf(stdout, "       --pipsolve                Use PIP as ILP solver\n");
+#ifdef GLPK
     fprintf(stdout, "       --glpk                    Use GLPK as ILP solver\n");
+#endif
     fprintf(stdout, "\n");
     fprintf(stdout, "\n  Optimizations          Options related to optimization\n");
     fprintf(stdout, "       --tile                    Tile for locality [disabled by default]\n");
@@ -198,6 +200,9 @@ int main(int argc, char *argv[])
         {"noisldepcoalesce", no_argument, &options->isldepcoalesce, 0},
         {"readscop", no_argument, &options->readscop, 1},
         {"pipsolve", no_argument, &options->pipsolve, 1},
+#ifdef GLPK
+        {"glpk", no_argument, &options->glpk, 1},
+#endif
         {"islsolve", no_argument, &options->islsolve, 1},
         {"time", no_argument, &options->time, 1},
         {0, 0, 0, 0}

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -404,6 +404,11 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
     IF_DEBUG(printf("[pluto] pluto_prog_constraints_lexmin (%d variables, %d constraints)\n",
                 cst->ncols-1, cst->nrows););
 
+#ifdef GLPK
+    if (options->glpk) {
+        pluto_prog_constraints_lexmin_glpk(newcst, prog);
+    }
+#endif
     /* Solve the constraints */
     sol = pluto_constraints_lexmin(newcst, DO_NOT_ALLOW_NEGATIVE_COEFF);
     /* print_polylib_visual_sets("csts", newcst); */

--- a/src/pluto.h
+++ b/src/pluto.h
@@ -31,6 +31,10 @@
 
 #include "osl/extensions/dependence.h"
 
+#ifdef GLPK
+#include <glpk.h>
+#endif
+
 /* Check out which piplib we are linking with */
 /* Candl/piplib_wrapper converts relation to matrices */
 #ifdef SCOPLIB_INT_T_IS_LONGLONG // Defined in src/Makefile.am
@@ -474,6 +478,4 @@ int pluto_are_stmts_fused(Stmt **stmts, int nstmts, const PlutoProg *prog);
 void pluto_iss_dep(PlutoProg *prog);
 PlutoConstraints *pluto_find_iss(const PlutoConstraints **doms, int ndoms, int npar, PlutoConstraints *);
 void pluto_iss(Stmt *stmt, PlutoConstraints **cuts, int num_cuts, PlutoProg *prog);
-
-
 #endif

--- a/src/program.c
+++ b/src/program.c
@@ -2727,6 +2727,7 @@ PlutoOptions *pluto_options_alloc()
 
     options->pipsolve = 0;
     options->islsolve = 1;
+    options->glpk = 0;
 
     options->readscop = 0;
 


### PR DESCRIPTION
glpk support enabled. Available as ` --enable-glpk`  option with configure.  When the option is provided with configure, it whether the dependencies are met, otherwise throws an error. If the option is not provided, it follows the usual compilation path, not involving glpk.