### PR TITLE
Add Gurobi solver as an option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,10 @@ dnl glpk flag
 AC_ARG_ENABLE(glpk,
               [  --enable-glpk  enable ILP solving with GLPK], glpk="true")
 
+gurobi="false"
+dnl check for gurobi
+AC_ARG_ENABLE(gurobi,
+              [  --enable-gurobi  enable ILP solving with GUROBI], gurobi="true")
 dnl check for programs
 AC_CHECK_PROG(CC,gcc,gcc)
 AC_PROG_CXX
@@ -86,6 +90,30 @@ if test $glpk = "true"; then
                                 , [AC_ERROR([glpk.h header not found])])
     AC_CHECK_LIB([glpk], [glp_create_prob], []
                  , [AC_ERROR([GLPK library not found])])
+fi
+
+dnl Offer --with-gurobi-prefix.
+AC_ARG_WITH(gurobi-prefix,
+            AC_HELP_STRING([--with-gurobi-prefix=DIR],
+                           [DIR location of GUROBI package]),
+                           [CPPFLAGS="${CPPFLAGS} -I$withval/include";
+                            LDFLAGS="${LDFLAGS} -L$withval/lib";
+                            # MAJOR_VERSION=`cat $withval/include/gurobi_c.h| grep VERSION_MAJOR`;
+                            # echo "major version = ${MAJOR_VERSION}";
+                            # LIBS="-lgurobi75 $LIBS";
+                            GUROBI_PREFIX="$withval";
+                            ])
+
+if test $gurobi = "true"; then
+    dnl check for gurobi
+    AC_CHECK_HEADER([gurobi_c.h],[AC_DEFINE([GUROBI],[1],[GUROBI solver for solving ILP])]
+                                   major_version=`cat $GUROBI_PREFIX/include/gurobi_c.h| grep VERSION_MAJOR| awk '{print $3}'`
+                                   minor_version=`cat $GUROBI_PREFIX/include/gurobi_c.h| grep VERSION_MINOR| awk '{print $3}'`
+                                   grb_version=gurobi$major_version$minor_version
+                                   CFLAGS="$CFLAGS -DGUROBI" LDFLAGS="$LDFLAGS -l$grb_version"
+                                   , [AC_ERROR([gurobi_c.h header not found])])
+    AC_CHECK_LIB([$grb_version], [GRBnewmodel], []
+                 , [AC_ERROR([Gurobi library not found])])
 fi
 
 dnl Offer --with-gmp-prefix.

--- a/include/pluto/libpluto.h
+++ b/include/pluto/libpluto.h
@@ -148,16 +148,16 @@ struct plutoOptions{
     /* Read input from a .scop file */
     int readscop;
 
-    /* Use PIP as ilp solver. */
+    /* Use PIP as the ILP solver. */
     int pipsolve;
 
-    /* Use isl as ilp solver. */
+    /* Use isl as the ILP solver. */
     int islsolve;
 
-    /* Use glpk as ilp solver. */
+    /* Use glpk as the ILP solver. */
     int glpk;
 
-    /* Use gurobi as ilp solver. */
+    /* Use gurobi as the ILP solver. */
     int gurobi;
 
     /* Use lp instead of ILP. */

--- a/include/pluto/libpluto.h
+++ b/include/pluto/libpluto.h
@@ -157,6 +157,9 @@ struct plutoOptions{
     /* Use glpk as ilp solver. */
     int glpk;
 
+    /* Use gurobi as ilp solver. */
+    int gurobi;
+
     /* Use lp instead of ILP. */
     int lp;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,7 @@ endif
 
 bin_PROGRAMS = pluto
 
-pluto_SOURCES = constraints.c constraints_polylib.c constraints_isl.c math_support.c ddg.c transforms.c pluto.c post_transform.c framework.c framework-dfp.c pluto_codegen_if.c polyloop.c ast_transform.c iss.c main.c constraints.h math_support.h pluto.h program.c program.h tile.c unit_tests.c
+pluto_SOURCES = constraints.c constraints_polylib.c constraints_isl.c math_support.c gurobi-plugin.c ddg.c transforms.c pluto.c post_transform.c framework.c framework-dfp.c pluto_codegen_if.c polyloop.c ast_transform.c iss.c main.c constraints.h math_support.h pluto.h program.c program.h tile.c unit_tests.c
 
 if PLUTO_DEBUG
 OPT_FLAGS = 

--- a/src/ast_transform.c
+++ b/src/ast_transform.c
@@ -77,7 +77,7 @@ void pluto_mark_parallel(struct clast_stmt *root, const PlutoProg *prog,
         }else{
             for (j=0; j<nloops; j++) {
                 loops[j]->parallel = CLAST_PARALLEL_NOT;
-                char *private_vars = malloc(128);
+                char *private_vars = malloc(512);
                 strcpy(private_vars, "lbv,ubv");
                 if (options->parallel) {
                     IF_DEBUG(printf("Marking %s parallel\n", loops[j]->iterator););

--- a/src/constraints.c
+++ b/src/constraints.c
@@ -1440,7 +1440,7 @@ int64 *pluto_prog_constraints_lexmin_glpk(const PlutoConstraints *cst,
         lp = get_scaling_lp_glpk(fpsol, num_sols, val, index, npar, num_ccs);
 
         scale_sols = pluto_mip_scale_solutions_glpk(lp);
-        int64 *sol = malloc(sizeof(int64)*(num_sols));
+        int64 *sol = (int64*)malloc(sizeof(int64)*(num_sols));
 
         /* Ideally u and w have to be set to be computed on a per CC basis. Since it is not 
          * used further down the tool chain, it is set to the maximum scaling factor.*/

--- a/src/constraints.h
+++ b/src/constraints.h
@@ -201,5 +201,6 @@ int pluto_constraints_get_num_non_zero_coeffs(const PlutoConstraints* cst);
 #ifdef GLPK
 int64 *pluto_prog_constraints_lexmin_glpk(const PlutoConstraints *cst, PlutoMatrix *obj, double **val, int** index, int npar, int num_ccs);
 double *pluto_fcg_constraints_lexmin_glpk(const PlutoConstraints* cst, PlutoMatrix *obj);
+int64 *pluto_prog_constraints_lexmin_gurobi(const PlutoConstraints *cst, PlutoMatrix *obj, double **val, int** index, int npar, int num_ccs);
 #endif
 #endif

--- a/src/constraints.h
+++ b/src/constraints.h
@@ -202,5 +202,6 @@ int pluto_constraints_get_num_non_zero_coeffs(const PlutoConstraints* cst);
 int64 *pluto_prog_constraints_lexmin_glpk(const PlutoConstraints *cst, PlutoMatrix *obj, double **val, int** index, int npar, int num_ccs);
 double *pluto_fcg_constraints_lexmin_glpk(const PlutoConstraints* cst, PlutoMatrix *obj);
 int64 *pluto_prog_constraints_lexmin_gurobi(const PlutoConstraints *cst, PlutoMatrix *obj, double **val, int** index, int npar, int num_ccs);
+double *pluto_fcg_constraints_lexmin_gurobi(const PlutoConstraints* cst, PlutoMatrix *obj);
 #endif
 #endif

--- a/src/constraints.h
+++ b/src/constraints.h
@@ -201,7 +201,11 @@ int pluto_constraints_get_num_non_zero_coeffs(const PlutoConstraints* cst);
 #ifdef GLPK
 int64 *pluto_prog_constraints_lexmin_glpk(const PlutoConstraints *cst, PlutoMatrix *obj, double **val, int** index, int npar, int num_ccs);
 double *pluto_fcg_constraints_lexmin_glpk(const PlutoConstraints* cst, PlutoMatrix *obj);
+#endif
+
+#ifdef GUROBI
 int64 *pluto_prog_constraints_lexmin_gurobi(const PlutoConstraints *cst, PlutoMatrix *obj, double **val, int** index, int npar, int num_ccs);
 double *pluto_fcg_constraints_lexmin_gurobi(const PlutoConstraints* cst, PlutoMatrix *obj);
 #endif
+
 #endif

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -53,11 +53,15 @@ static double rtclock()
 
 /* Checks for feasibility of constraints.
  * If feasible then return the solution else returns NULL */
-/* double* pluto_fusion_constraints_feasibility_solve_glpk(PlutoConstraints *cst, PlutoProg *prog, int src_dim, int target_dim, int fcg_src, int fcg_dest) */
-double* pluto_fusion_constraints_feasibility_solve_glpk(PlutoConstraints *cst, PlutoMatrix *obj)
+double* pluto_fusion_constraints_feasibility_solve(PlutoConstraints *cst, PlutoMatrix *obj)
 {
     double* sol;
-    sol = pluto_fcg_constraints_lexmin_glpk(cst, obj);
+    if (options->gurobi) {
+        sol = pluto_fcg_constraints_lexmin_gurobi(cst, obj);
+    } else {
+        sol = pluto_fcg_constraints_lexmin_glpk(cst, obj);
+    }
+
     return sol;
 }
 
@@ -151,7 +155,7 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
 
                     prog->num_lp_calls ++;
                     tstart = rtclock();
-                    sol = pluto_fusion_constraints_feasibility_solve_glpk(conflictcst, obj);
+                    sol = pluto_fusion_constraints_feasibility_solve(conflictcst, obj);
                     prog->cst_solve_time += rtclock() - tstart;
 
                     /* If no solutions, then dimensions are not fusable. Add an edge in the conflict graph. */
@@ -278,7 +282,7 @@ void add_permute_preventing_edges(Graph* fcg, int *colour, PlutoProg *prog, Plut
                     /* coeff_bounds->val[0][stmt_offset+j] = 1; */
                     prog->num_lp_calls++;
 
-                    sol = pluto_fusion_constraints_feasibility_solve_glpk(coeff_bounds,obj);
+                    sol = pluto_fusion_constraints_feasibility_solve(coeff_bounds,obj);
                     /* If the constraints are infeasible then add a self edge in the FCG */
 
                     if (sol == NULL) {

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -55,7 +55,8 @@ static double rtclock()
  * If feasible then return the solution else returns NULL */
 double* pluto_fusion_constraints_feasibility_solve(PlutoConstraints *cst, PlutoMatrix *obj)
 {
-    double* sol;
+    double* sol, tstart;
+    tstart = rtclock();
     if (options->gurobi) {
 #ifdef GUROBI
         sol = pluto_fcg_constraints_lexmin_gurobi(cst, obj);
@@ -65,6 +66,7 @@ double* pluto_fusion_constraints_feasibility_solve(PlutoConstraints *cst, PlutoM
         sol = pluto_fcg_constraints_lexmin_glpk(cst, obj);
 #endif
     }
+    prog->mipTime += rtclock()-tstart;
 
     return sol;
 }
@@ -158,9 +160,7 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
                      * of the target is valid */
 
                     prog->num_lp_calls ++;
-                    tstart = rtclock();
                     sol = pluto_fusion_constraints_feasibility_solve(conflictcst, obj);
-                    prog->cst_solve_time += rtclock() - tstart;
 
                     /* If no solutions, then dimensions are not fusable. Add an edge in the conflict graph. */
                     if(sol == NULL)
@@ -1047,10 +1047,10 @@ int scale_shift_permutations(PlutoProg *prog, int *colour, int c)
                     H_SCALAR: H_LOOP;
 
             }
+            prog->scaling_cst_sol_time += rtclock()-t_start;
             free(sol);
             IF_DEBUG(pluto_transformation_print_level(prog, prog->num_hyperplanes-1););
             pluto_constraints_free(coeffcst);
-            prog->scaling_cst_sol_time += rtclock()-t_start;
             return 1;
         } else {
             printf("[pluto] No Hyperplane found\n");

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -36,7 +36,7 @@
 #include <isl/set.h>
 #include "candl/candl.h"
 
-#ifdef GLPK
+#if defined GLPK || defined GUROBI
 int scale_shift_permutations(PlutoProg *prog, int *colour, int c);
 
 static double rtclock()
@@ -57,9 +57,13 @@ double* pluto_fusion_constraints_feasibility_solve(PlutoConstraints *cst, PlutoM
 {
     double* sol;
     if (options->gurobi) {
+#ifdef GUROBI
         sol = pluto_fcg_constraints_lexmin_gurobi(cst, obj);
+#endif
     } else {
+#ifdef GLPK
         sol = pluto_fcg_constraints_lexmin_glpk(cst, obj);
+#endif
     }
 
     return sol;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -61,7 +61,7 @@ double* pluto_fusion_constraints_feasibility_solve(PlutoConstraints *cst, PlutoM
 #ifdef GUROBI
         sol = pluto_fcg_constraints_lexmin_gurobi(cst, obj);
 #endif
-    } else {
+    }else{
 #ifdef GLPK
         sol = pluto_fcg_constraints_lexmin_glpk(cst, obj);
 #endif

--- a/src/gurobi-plugin.c
+++ b/src/gurobi-plugin.c
@@ -402,6 +402,8 @@ double *pluto_fcg_constraints_lexmin_gurobi(const PlutoConstraints* cst, PlutoMa
     /* Create gurobi model. Add objective and variable types during creation of the object itself */
     GRBnewmodel(env, &lp, NULL, num_vars, grb_obj, NULL, NULL, vtype, NULL);
 
+    set_gurobi_constraints_from_pluto_constraints(lp, cst);
+
     if (options->debug) {
         GRBwrite(lp, "pluto-pairwise-constraints-gurobi.lp");
     }

--- a/src/gurobi-plugin.c
+++ b/src/gurobi-plugin.c
@@ -1,3 +1,4 @@
+#ifdef GUROBI
 #include "constraints.h"
 #include "pluto.h"
 #include <math.h>
@@ -420,3 +421,4 @@ double *pluto_fcg_constraints_lexmin_gurobi(const PlutoConstraints* cst, PlutoMa
     }
 
 }
+#endif

--- a/src/gurobi-plugin.c
+++ b/src/gurobi-plugin.c
@@ -218,9 +218,6 @@ GRBmodel *get_scaling_lp_gurobi(double *fpsol, int num_sols, double **val, int *
 
     num_sols_to_be_scaled = num_sols-npar-1;
 
-    printf("Num sols to be scaled %d\n", num_sols_to_be_scaled);
-    printf("num_ccs: %d \n", num_ccs);
-
     vtype = (char*)malloc(num_sols_to_be_scaled + num_ccs);
     for (i=0; i<num_ccs; i++) {
         vtype[i] = GRB_CONTINUOUS;
@@ -336,7 +333,6 @@ int64 *pluto_prog_constraints_lexmin_gurobi(const PlutoConstraints *cst,
         num_sols = num_vars;
         GRBfreemodel(lp);
         /* GRBfreeenv(env); */
-        printf("LP solutions found with gurobi\n");
 
         /* GRBloadenv(&env, NULL); */
         lp = get_scaling_lp_gurobi(fpsol, num_sols, val, index, npar, num_ccs, env);
@@ -344,11 +340,9 @@ int64 *pluto_prog_constraints_lexmin_gurobi(const PlutoConstraints *cst,
         if (options->debug) {
             GRBwrite(lp, "pluto-scaling-mip.lp");
         }
-        printf("Scaling MIP constructed for gurobi \n");
 
         scale_sols = pluto_mip_scale_solutions_gurobi(lp);
 
-        printf("Scaling MIP solved gurobi \n");
         max_scale_factor = get_max_scale_factor(scale_sols, num_ccs);
 
         sol =(int64*)malloc(sizeof(int64)*num_sols);

--- a/src/gurobi-plugin.c
+++ b/src/gurobi-plugin.c
@@ -1,0 +1,166 @@
+#include "constraints.h"
+#include "pluto.h"
+#include <math.h>
+#include <assert.h>
+#include <gurobi_c.h>
+
+inline void check_error_gurobi(GRBmodel *lp, int error)
+{
+    if(error) {
+        GRBenv *env;
+        env = GRBgetenv(lp);
+        printf("ERROR: %s\n", GRBgeterrormsg(env));
+        exit(1);
+
+    }
+}
+
+double* get_gurobi_objective_from_pluto_matrix(PlutoMatrix *obj)
+{
+    int j;
+    double *grb_obj;
+    assert (obj->nrows == 1);
+    grb_obj = (double*) malloc(sizeof(double)*(obj->ncols));
+    for (j=0; j<obj->ncols; j++) {
+        grb_obj[j] = (double)(obj->val[0][j]);
+    }
+    return grb_obj;
+}
+
+/* Constructs constraints for gurobi problem from pluto_constraints.
+ * Assumes that there are no rows or cols in the input model lp */
+void set_gurobi_constraints_from_pluto_constraints (GRBmodel *lp, const PlutoConstraints *cst)
+{
+    int i, j, k, nrows, ncols;
+    int *index;
+    double *value, rhs;
+
+    nrows = cst->nrows;
+    ncols = cst->ncols-1;
+
+    index = (int*) malloc ((ncols)*sizeof(int));
+    value = (double*) malloc ((ncols)*sizeof(double));
+
+    /* non_zero = pluto_constraints_get_num_non_zero_coeffs(cst); */
+    /* row = (int*)malloc((non_zero)*sizeof(int)); */
+    /* col = (int*)malloc((non_zero)*sizeof(int)); */
+    /* coeff = (double*)malloc((non_zero)*sizeof(double)); */
+
+    /*Populate the constraints row by row. */
+    for (i=0; i<nrows; i++) {
+        k = 0;
+        for (j=0; j<ncols; j++) {
+            if (cst->val[i][j] != 0) {
+                index[k] = j;
+                value[k] = (double) cst->val[i][j];
+                k++;
+            }
+        }
+        rhs = (double) -(cst->val[i][ncols]);
+        /* Trivial constraint. can be skipped */
+        if(k == 0) {
+            continue;
+        }
+        if (cst->is_eq[i]) {
+            /* For equality constraints the bounds are fixed */
+            GRBaddconstr(lp, k, index, value, GRB_EQUAL, rhs, NULL);
+        } else {
+            /* Add a lower bound on each row of the inequality */
+            GRBaddconstr(lp, k, index, value, GRB_GREATER_EQUAL, rhs, NULL);
+        }
+    }
+    free(index);
+    free(value);
+}
+
+/* Retrives ilp solution from the input glpk problem. 
+ * Assumes that the optimal solution exists and has been found*/
+int64* get_ilp_solution_from_gurobi_problem(GRBmodel *lp)
+{
+    int num_cols, i, error;
+    int64 *sol;
+    double x;
+
+        error = GRBgetintattr(lp, GRB_INT_ATTR_NUMVARS, &num_cols);
+        check_error_gurobi(lp, error);
+
+        sol = (int64*) malloc (num_cols*sizeof(int64));
+
+        for (i=0; i<num_cols; i++) {
+            error = GRBgetdblattrelement(lp, GRB_DBL_ATTR_X, i, &x);
+            IF_DEBUG(printf("c%d = %lld, ", i, (int64) round(x)););
+            sol[i] = (int64) round(x);
+
+        }
+        return sol;
+}
+
+int64 *pluto_prog_constraints_lexmin_gurobi(const PlutoConstraints *cst, 
+        PlutoMatrix *obj, double **val, int**index, int npar, int num_ccs)
+{
+    int i, j, is_unsat, num_sols;
+    int num_vars;
+    double *grb_obj;
+    char* vtype;
+
+    int64 *sol;
+
+    double objval;
+    int optim_status;
+
+    
+    num_vars = cst->ncols-1;
+    
+    GRBenv *env = NULL;
+    GRBmodel *lp = NULL;
+     IF_DEBUG(printf("[pluto] pluto_prog_constraints_lexmin_gurobi (%d variables, %d constraints)\n",
+                                 cst->ncols-1, cst->nrows););
+     GRBloadenv(&env, NULL);
+
+     grb_obj = get_gurobi_objective_from_pluto_matrix(obj);
+
+     vtype = (char*)malloc(sizeof(char)*num_vars);
+
+     /* Create gurobi model. Add objective during creation itself */
+     GRBnewmodel(env, &lp, NULL, num_vars, grb_obj, NULL, NULL, NULL, NULL);
+
+     /* Set objective direction to minimization */
+     GRBsetdblattr(lp, GRB_INT_ATTR_MODELSENSE, GRB_MINIMIZE);
+
+     set_gurobi_constraints_from_pluto_constraints(lp, cst);
+
+     /* Set integer constraints on all variables of the ILP */
+     if (!options->lp) {
+         for (i = 0; i<num_vars; i++) {
+             vtype[i] = GRB_INTEGER;
+         }
+     }
+
+     if (options->debug) {
+         GRBwrite(lp, "pluto.lp");
+     }
+
+     GRBoptimize(lp);
+
+     free(grb_obj);
+
+     GRBgetintattr(lp, GRB_INT_ATTR_STATUS, &optim_status);
+
+     if (optim_status == GRB_INF_OR_UNBD) {
+         GRBfreemodel(lp);
+         GRBfreeenv(env);
+         return NULL;
+     }
+
+     GRBgetdblattr(lp, GRB_DBL_ATTR_OBJVAL, &objval);
+     IF_DEBUG(printf("Objective value: %0.6f\n",objval););
+     
+     sol = get_ilp_solution_from_gurobi_problem(lp);
+
+         GRBfreemodel(lp);
+         GRBfreeenv(env);
+
+     return sol;
+
+
+}

--- a/src/gurobi-plugin.c
+++ b/src/gurobi-plugin.c
@@ -155,6 +155,13 @@ int64 *pluto_prog_constraints_lexmin_gurobi(const PlutoConstraints *cst,
          return NULL;
      }
 
+     if (optim_status == GRB_UNBOUNDED) {
+         GRBfreemodel(lp);
+         GRBfreemodel(env);
+         printf("[Pluto]: Unbounded model. This appears to be a problem in Pluto's ILP/LP construction. Aborting\n");
+         exit(1);
+     }
+
      GRBgetdblattr(lp, GRB_DBL_ATTR_OBJVAL, &objval);
      IF_DEBUG(printf("Objective value: %0.6f\n",objval););
      

--- a/src/main.c
+++ b/src/main.c
@@ -362,7 +362,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
     if (options->gurobi) {
         options->islsolve = 0;
     }
-    if (options->lp && !options->glpk) {
+    if (options->lp && !(options->glpk || options->gurobi)) {
         printf("[pluto]: LP option available with a LP solver only. Using GLPK for lp solving\n");
         options->glpk = 1;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@ void usage_message(void)
     fprintf(stdout, "       --islsolve [default]      Use ISL as ILP solver (default)\n");
     fprintf(stdout, "       --pipsolve                Use PIP as ILP solver\n");
 #ifdef GLPK
-    fprintf(stdout, "       --glpk                    Use GLPK as ILP solver\n");
+    fprintf(stdout, "       --glpk                    Use GLPK as ILP solver (default in case of pluto-lp and pluto-dfp)\n");
 #endif
 #if defined GLPK || defined GUROBI
     fprintf(stdout, "       --lp                      Solve MIP instead of ILP\n");
@@ -366,10 +366,10 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
         options->parallel = 1;
     }
 
-#ifdef GLPK
     if (options->gurobi) {
         options->islsolve = 0;
     }
+#ifdef GLPK
     if (options->lp && !(options->glpk || options->gurobi)) {
         printf("[pluto]: LP option available with a LP solver only. Using GLPK for lp solving\n");
         options->glpk = 1;
@@ -392,8 +392,8 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
 
 #endif
 
-    if(options->dfp && !(options->glpk || options->gurobi)) {
-        printf ("[pluto]: ERROR: DFP framework currently supported with GLPK solver only. Configure Pluto with --enable-glpk \n");
+    if (options->dfp && !(options->glpk || options->gurobi)) {
+        printf ("[pluto]: ERROR: DFP framework is currently supported with GLPK or GUROBI solvers only. Run ./configure --help to for more information on using different solvers with Pluto.\n");
         pluto_options_free(options);
         usage_message();
         return 1;

--- a/src/main.c
+++ b/src/main.c
@@ -212,11 +212,15 @@ int main(int argc, char *argv[])
         {"pipsolve", no_argument, &options->pipsolve, 1},
 #ifdef GLPK
         {"glpk", no_argument, &options->glpk, 1},
+#endif
+#ifdef GUROBI
+        {"gurobi", no_argument, &options->gurobi, 1},
+#endif
+#if defined GLPK || defined GUROBI
         {"lp", no_argument, &options->lp, 1},
         {"dfp", no_argument, &options->dfp, 1},
         {"ilp", no_argument, &options->ilp, 1},
         {"lpcolor", no_argument, &options->lpcolour, 1},
-        {"gurobi", no_argument, &options->gurobi, 1},
 #endif
         {"islsolve", no_argument, &options->islsolve, 1},
         {"time", no_argument, &options->time, 1},

--- a/src/main.c
+++ b/src/main.c
@@ -68,6 +68,7 @@ void usage_message(void)
     fprintf(stdout, "       --ilp                     Use ILP in pluto-lp-dfp instead of LP\n");
     fprintf(stdout, "       --lpcolor                 Color FCG based on the solutions of the lp-problem [disabled by default]\n");
     fprintf(stdout, "\n");
+    fprintf(stdout, "       --gurobi                  Use Gurobi as ILP solver\n");
 #endif
     fprintf(stdout, "\n");
     fprintf(stdout, "\n  Optimizations          Options related to optimization\n");
@@ -211,6 +212,7 @@ int main(int argc, char *argv[])
         {"dfp", no_argument, &options->dfp, 1},
         {"ilp", no_argument, &options->ilp, 1},
         {"lpcolor", no_argument, &options->lpcolour, 1},
+        {"gurobi", no_argument, &options->gurobi, 1},
 #endif
         {"islsolve", no_argument, &options->islsolve, 1},
         {"time", no_argument, &options->time, 1},
@@ -357,6 +359,9 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
     }
 
 #ifdef GLPK
+    if (options->gurobi) {
+        options->islsolve = 0;
+    }
     if (options->lp && !options->glpk) {
         printf("[pluto]: LP option available with a LP solver only. Using GLPK for lp solving\n");
         options->glpk = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -372,8 +372,9 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
         options->lp = 1;
     }
         
-    if (options->dfp && !options->glpk) {
-        printf("[pluto]: Dfp framework is currently supported only with GLPK solver. Using GLPK for constraint solving \n");
+    if (options->dfp && !(options->glpk || options->gurobi)) {
+        printf("[pluto]: Dfp framework is currently supported with GLPK and Gurobi solvers.\n"); 
+        printf("[pluto]: Using GLPK for constraint solving [default]. Use --gurobi to use Gurobi instead of GLPK.\n");
         options->glpk = 1;
     } 
     if (options->glpk) {
@@ -383,7 +384,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
 
 #endif
 
-    if(options->dfp && !options->glpk) {
+    if(options->dfp && !(options->glpk || options->gurobi)) {
         printf ("[pluto]: ERROR: DFP framework currently supported with GLPK solver only. Configure Pluto with --enable-glpk \n");
         pluto_options_free(options);
         usage_message();

--- a/src/main.c
+++ b/src/main.c
@@ -63,11 +63,15 @@ void usage_message(void)
     fprintf(stdout, "       --pipsolve                Use PIP as ILP solver\n");
 #ifdef GLPK
     fprintf(stdout, "       --glpk                    Use GLPK as ILP solver\n");
+#endif
+#if defined GLPK || defined GUROBI
     fprintf(stdout, "       --lp                      Solve MIP instead of ILP\n");
     fprintf(stdout, "       --dfp                     Use Pluto-lp-dfp instead of pluto-ilp [disabled by default]\n");
     fprintf(stdout, "       --ilp                     Use ILP in pluto-lp-dfp instead of LP\n");
     fprintf(stdout, "       --lpcolor                 Color FCG based on the solutions of the lp-problem [disabled by default]\n");
+#endif
     fprintf(stdout, "\n");
+#ifdef GUROBI
     fprintf(stdout, "       --gurobi                  Use Gurobi as ILP solver\n");
 #endif
     fprintf(stdout, "\n");

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -354,6 +354,7 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
         int **index = NULL;
         int num_ccs, nrows;
         num_ccs = 0;
+        nrows = 0;
 
         PlutoMatrix *obj = construct_cplex_objective(newcst, prog);
 

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -348,7 +348,7 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
         prog->mipTime += rtclock()-t_start;
     }
 #ifdef GLPK
-    else if (options->glpk || options->lp || options->dfp) {
+    else if (options->glpk || options->lp || options->dfp || options->gurobi) {
          
         double **val = NULL;
         int **index = NULL;
@@ -368,7 +368,7 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
         sol = pluto_prog_constraints_lexmin_glpk(newcst, obj, val, index, npar, num_ccs);
         } 
         else if (options->gurobi) {
-            sol = pluto_prog_constraints_lexmin_gurobi(newcst, obj, val, index, par, num_ccs);
+            sol = pluto_prog_constraints_lexmin_gurobi(newcst, obj, val, index, npar, num_ccs);
         }
         prog->mipTime += rtclock()-t_start;
 

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -385,8 +385,7 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
             free(val);
             free(index);
         }
-    }
-    else {
+    }else{
         t_start = rtclock(); 
         sol = pluto_constraints_lexmin_pip(newcst, DO_NOT_ALLOW_NEGATIVE_COEFF);
         prog->mipTime += rtclock()-t_start;

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -364,7 +364,12 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
         }
 
         t_start = rtclock(); 
+        if (options->glpk) {
         sol = pluto_prog_constraints_lexmin_glpk(newcst, obj, val, index, npar, num_ccs);
+        } 
+        else if (options->gurobi) {
+            sol = pluto_prog_constraints_lexmin_gurobi(newcst, obj, val, index, par, num_ccs);
+        }
         prog->mipTime += rtclock()-t_start;
 
         pluto_matrix_free(obj);

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -1724,7 +1724,7 @@ int pluto_auto_transform(PlutoProg *prog)
     /* Pluto algo mode -- LAZY or EAGER */
     bool hyp_search_mode;
 
-#ifdef GLPK
+#if defined GLPK || defined GUROBI
     Graph* fcg;
     int *colour, nVertices;
 #endif
@@ -1818,7 +1818,7 @@ int pluto_auto_transform(PlutoProg *prog)
     conc_start_found = 0;
 
     if (options->dfp) {
-#ifdef GLPK
+#if defined GLPK || defined GUROBI
         if(options->fuse == NO_FUSE) {
             ddg_compute_scc(prog);
             cut_all_sccs(prog, ddg);
@@ -1997,7 +1997,7 @@ int pluto_auto_transform(PlutoProg *prog)
 
  /* Deallocate the fusion conflict graph */
     if (options->dfp){
-#ifdef GLPK
+#if defined GLPK || defined GUROBI
         ddg = prog->ddg;
         for(i=0; i<ddg->num_sccs; i++){
             free(ddg->sccs[i].vertices);

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -347,7 +347,6 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
         sol = pluto_constraints_lexmin_isl(newcst, DO_NOT_ALLOW_NEGATIVE_COEFF);
         prog->mipTime += rtclock()-t_start;
     }
-#ifdef GLPK
     else if (options->glpk || options->lp || options->dfp || options->gurobi) {
          
         double **val = NULL;
@@ -366,10 +365,14 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
 
         t_start = rtclock(); 
         if (options->glpk) {
+#ifdef GLPK
         sol = pluto_prog_constraints_lexmin_glpk(newcst, obj, val, index, npar, num_ccs);
+#endif
         } 
         else if (options->gurobi) {
+#ifdef GUROBI
             sol = pluto_prog_constraints_lexmin_gurobi(newcst, obj, val, index, npar, num_ccs);
+#endif
         }
         prog->mipTime += rtclock()-t_start;
 
@@ -383,7 +386,6 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
             free(index);
         }
     }
-#endif
     else {
         t_start = rtclock(); 
         sol = pluto_constraints_lexmin_pip(newcst, DO_NOT_ALLOW_NEGATIVE_COEFF);

--- a/src/program.c
+++ b/src/program.c
@@ -2729,6 +2729,7 @@ PlutoOptions *pluto_options_alloc()
     options->pipsolve = 0;
     options->islsolve = 1;
     options->glpk = 0;
+    options->gurobi = 0;
 
     options->lp = 0;
     options->dfp = 0;


### PR DESCRIPTION
Integrate Pluto with Gurobi solver. Pluto must be configured with `--enable-gurobi` and the path of Gurobi installation has to be provided with `--with-gurobi-prefix=`. Constraint solving with Gurobi is available with the command-line option `--gurobi` to pluto