### PR TITLE
Fix "TypeError: cannot copy this pattern object"

### DIFF
--- a/orio-0.1.0/src/tool/ZestyParser/Tokens.py
+++ b/orio-0.1.0/src/tool/ZestyParser/Tokens.py
@@ -183,7 +183,7 @@ class AbstractToken (object):
         n = self.__class__.__new__(self.__class__)
         n.__dict__.update(self.__dict__)
         n._poke()
-        n.desc = copy.copy(self.desc)
+        n.desc = self.desc
         return n
     
     def __setattr__(self, name, value):


### PR DESCRIPTION
This is related to the issue that python 2.5+ cannot copy SRE object. Related issues/bug report:https://bugs.python.org/issue10076 https://bugzilla.redhat.com/show_bug.cgi?id=1075503.

This is a temporary fix since according to the first bug report discussion, 
> Since the pattern and the match objects can be considered as immutable, it is worth to implement __copy__ and __deepcopy__ returning the object itself. 

This fix essentially does just that. Otherwise using Python 2.7.9 we had: 
```
TypeError: cannot copy this pattern object
```
when performing loop unrolling.
