### PR TITLE
Pluto-lp-dfp with scc clustering heuristics and typed fuse

### DIFF
--- a/include/pluto/libpluto.h
+++ b/include/pluto/libpluto.h
@@ -62,6 +62,9 @@ struct plutoOptions{
     /* For experimental purposes with dfp */
     int delayed_cut;
 
+    /* Tyepd fuse at outer levels, max fuse at inner levels */
+    int hybridcut;
+
     /* for debugging - print default cloog-style total */
     int scancount;
 
@@ -203,6 +206,8 @@ typedef struct plutoOptions PlutoOptions;
 #define SMART_FUSE 2
 /* Fuses SCCs only if fusion does not result in loss of parallelism */
 #define TYPED_FUSE 3
+/* Typed fuse at outer levels, Max fuse at inner levels */
+# define HYBRID_FUSE 4
 
 
 PlutoOptions *pluto_options_alloc();

--- a/include/pluto/libpluto.h
+++ b/include/pluto/libpluto.h
@@ -59,6 +59,9 @@ struct plutoOptions{
     /* Decides the fusion algorithm (MAXIMAL_FUSE, NO_FUSE, or SMART_FUSE) */
     int fuse;
 
+    /* For experimental purposes with dfp */
+    int delayed_cut;
+
     /* for debugging - print default cloog-style total */
     int scancount;
 

--- a/src/ddg.h
+++ b/src/ddg.h
@@ -47,6 +47,9 @@ struct scc{
     /* Set to true if the scc is couloured with current colour else false */
     bool is_scc_coloured;
 
+    /* Set to true if there is a parallel hyperplane has already been found for this scc */
+    bool has_parallel_hyperplane;
+
 };
 typedef struct scc Scc;
 

--- a/src/ddg.h
+++ b/src/ddg.h
@@ -44,6 +44,9 @@ struct scc{
      * when used with SCC based clustering heuristic */
     int fcg_scc_offset;
 
+    /* Set to true if the scc is couloured with current colour else false */
+    bool is_scc_coloured;
+
 };
 typedef struct scc Scc;
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -2048,7 +2048,7 @@ bool are_sccs_fused(PlutoProg *prog, int scc1, int scc2)
     return sccs_fused;
 }
 
-/* Routines adds a scalr hyperplane between two SCCs.
+/* Routine adds a scalar hyperplane between two SCCs.
  * Note that SCCs might not be connected. Ideally this routine
  * can be moved to pluto.c (or framework.c) and approprite 
  * changes can be made in DDG cut routines */
@@ -2078,6 +2078,9 @@ void pluto_add_scalar_hyperplanes_between_sccs(PlutoProg *prog, int scc1, int sc
     }
 }
 
+/* Routine adds a hyperplane (H_LOOP) from the solution an ILP solution. 
+ * This method can also be moved to framework.c (or pluto.c) and 
+ * appropriate changes can be made. */
 void add_hyperplane_from_ilp_solution (int64 *sol, PlutoProg *prog)
 {
     int j, k;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -269,11 +269,11 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
         /*if (options->varliberalize && dep->skipdep) {
           continue;
           }*/
-        if(dep_is_satisfied(dep)){
+        if (dep_is_satisfied(dep)){
             continue;
         }
         if ((dep->src == v1 && dep->dest == v2)||(dep->src==v2 && dep->dest ==v1)){
-            if(dep->cst == NULL){
+            if (dep->cst == NULL){
                 compute_pairwise_permutability(dep,prog);
             }
             IF_DEBUG(printf("Adding Constraints for dependence %d\n",i););
@@ -309,15 +309,15 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
 
     /* Solve Pluto LP by setting corresponding coeffs to 0 without any objective.
      * This is the check for fusability of two dimensions */
-    for(i=0; i<stmts[v1]->dim_orig; i++){
+    for (i=0; i<stmts[v1]->dim_orig; i++){
         /* note that the vertex should not be coloured. Even if the vertex has a 
          * self edge, it must be considered during construction of the FCG. This
          * is because,even after satisfying the permute preventing dep, it might
          * still prevent fusion. */
         if (colour[fcg_offset1 + i] == 0 || colour[fcg_offset1 + i] == current_colour) {
-            if(fcg->adj->val[fcg_offset1+i][fcg_offset1+i]==1) {
+            if (fcg->adj->val[fcg_offset1+i][fcg_offset1+i]==1) {
                 /* Do not solve LPs if a dimenion of a statement is not permutable */
-                for(j=0;j<stmts[v2]->dim_orig; j++) {
+                for (j=0;j<stmts[v2]->dim_orig; j++) {
                     fcg->adj->val[fcg_offset1+i][fcg_offset2+j]=1;
                 }
                 continue;
@@ -329,7 +329,7 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
 
             for (j=0; j<stmts[v2]->dim_orig; j++) {
                 if (colour[fcg_offset2 + j] == 0 || colour[fcg_offset2 + j] == current_colour) {
-                    if(fcg->adj->val[fcg_offset1+i][fcg_offset1+i]==1) {
+                    if (fcg->adj->val[fcg_offset1+i][fcg_offset1+i]==1) {
                         fcg->adj->val[fcg_offset1+i][fcg_offset2+j]=1;
                         continue;
 
@@ -348,8 +348,7 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
                     prog->mipTime += rtclock()-tstart;
 
                     /* If no solutions, then dimensions are not fusable. Add an edge in the conflict graph. */
-                    if(sol == NULL)
-                    {
+                    if (sol == NULL) {
                         IF_DEBUG(printf("Unable to fuse Dimesnion %d of statement %d with dimension %d of statement %d \n",i,v1,j,v2););
                         IF_DEBUG(printf(" Adding edge %d to %d in fcg\n",fcg_offset1+i,fcg_offset2+j););
                         fcg->adj->val[fcg_offset1+i][fcg_offset2+j] = 1;
@@ -456,7 +455,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
         scc1_fcg_offset = sccs[scc1].fcg_scc_offset;
         for (scc2=scc1+1; scc2<num_sccs; scc2++) {
             scc2_fcg_offset = sccs[scc2].fcg_scc_offset;
-            if(ddg_sccs_direct_connected(ddg, prog, scc1, scc2)) {
+            if (ddg_sccs_direct_connected(ddg, prog, scc1, scc2)) {
                 inter_scc_constraints = get_inter_scc_dep_constraints (scc1, scc2, prog);
                 if ((sccs[scc1].is_parallel || sccs[scc2].is_parallel) && options->fuse == TYPED_FUSE) {
                     check_parallel = true;
@@ -497,7 +496,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                         /* Set lb of dim1 of each statement in Scc 1 */
                         for (i=0; i<sccs[scc1].size; i++) {
                             stmt1 = sccs[scc1].vertices[i];
-                            if(dim1<=stmts[stmt1]->dim_orig) {
+                            if (dim1<=stmts[stmt1]->dim_orig) {
                                 stmt1_offset = npar+1+(nvar+1)*stmt1;
                                 inter_scc_constraints->val[row_offset+stmt1_offset+dim1][CST_WIDTH-1] = -1;
                                 inter_scc_constraints->is_eq[row_offset+stmt1_offset+dim1] = 0;
@@ -512,7 +511,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                                 }
                                 for (j=0; j<sccs[scc2].size; j++) {
                                     stmt2 = sccs[scc2].vertices[j];
-                                    if(dim2<=stmts[stmt2]->dim_orig) {
+                                    if (dim2<=stmts[stmt2]->dim_orig) {
                                         stmt2_offset = npar+1+(nvar+1)*stmt2;
                                         inter_scc_constraints->val[row_offset+stmt2_offset+dim2][CST_WIDTH-1] = -1;
                                         inter_scc_constraints->is_eq[row_offset+stmt2_offset+dim2] = 0;
@@ -527,8 +526,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                                 prog->mipTime += rtclock()-tstart;
 
                                 /* If no solutions, then dimensions are not fusable. Add an edge in the conflict graph. */
-                                if(sol == NULL)
-                                {
+                                if (sol == NULL) {
                                     IF_DEBUG(printf("Unable to fuse dimension %d of scc %d with dimension %d of scc %d \n",dim1,scc1 ,dim2 ,scc2););
                                     IF_DEBUG(printf(" Adding edge %d to %d in fcg\n",scc1_fcg_offset+dim1,scc2_fcg_offset+dim2););
                                     fcg->adj->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 1;
@@ -546,7 +544,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                                 /* Reset the lower bounds of dimensions of each statement in SCC2 */
                                 for (j=0; j<sccs[scc2].size; j++) {
                                     stmt2 = sccs[scc2].vertices[j];
-                                    if(dim2<=stmts[stmt2]->dim_orig) {
+                                    if (dim2<=stmts[stmt2]->dim_orig) {
                                         stmt2_offset = npar+1+(nvar+1)*stmt2;
                                         inter_scc_constraints->val[row_offset+stmt2_offset+dim2][CST_WIDTH-1] = 0;
                                         inter_scc_constraints->is_eq[row_offset+stmt2_offset+dim2] = 1;
@@ -557,7 +555,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                         /* Set lb of dim1 of each statement in Scc 1 */
                         for (i=0; i<sccs[scc1].size; i++) {
                             stmt1 = sccs[scc1].vertices[i];
-                            if(dim1<=stmts[stmt1]->dim_orig) {
+                            if (dim1<=stmts[stmt1]->dim_orig) {
                                 stmt1_offset = npar+1+(nvar+1)*stmt1;
                                 inter_scc_constraints->val[row_offset+stmt1_offset+dim1][CST_WIDTH-1] = 0;
                                 inter_scc_constraints->is_eq[row_offset+stmt1_offset+dim1] = -1;
@@ -804,7 +802,7 @@ void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, Pluto
                     /* Set the lower bounds of the jth coefficient for all the statments in scc i to 1. */
                     for (k=0; k<sccs[i].size; k++) {
                         stmt_id = sccs[i].vertices[k];
-                        if(stmts[stmt_id]->is_orig_loop[j]) {
+                        if (stmts[stmt_id]->is_orig_loop[j]) {
                             stmt_offset = npar+1+stmt_id*(nvar+1)+j;
                             coeff_bounds->is_eq[nrows+stmt_offset] = 0;
                             coeff_bounds->val[nrows+stmt_offset][CST_WIDTH-1] = -1;
@@ -838,7 +836,7 @@ void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, Pluto
                     /* reset the coeff bound of this dimension for all statements in the SCC*/
                     for (k=0; k<sccs[i].size; k++) {
                         stmt_id = sccs[i].vertices[k];
-                        if(j<=stmts[stmt_id]->dim_orig) {
+                        if (j<=stmts[stmt_id]->dim_orig) {
                             stmt_offset = npar+1+stmt_id*(nvar+1)+j;
                             coeff_bounds->is_eq[nrows+stmt_offset] = 1;
                             coeff_bounds->val[nrows+stmt_offset][CST_WIDTH-1] = 0;
@@ -869,7 +867,7 @@ void update_scc_cluster_fcg_between_sccs(Graph *fcg, int scc1, int scc2, PlutoPr
     num_sccs = ddg->num_sccs;
     assert (scc1 != scc2);
 
-    if(options->fuse == NO_FUSE) {
+    if (options->fuse == NO_FUSE) {
         for (i=0; i<num_sccs; i++) {
             scc1_fcg_offset = sccs[i].fcg_scc_offset;
             for (dim1 = 0; dim1<=sccs[i].max_dim ; dim1++) {
@@ -877,7 +875,7 @@ void update_scc_cluster_fcg_between_sccs(Graph *fcg, int scc1, int scc2, PlutoPr
                     scc2_fcg_offset = sccs[j].fcg_scc_offset;
                     for (dim2=0; dim2<=sccs[j].max_dim; dim2++) {
                         /* No fusion. Hence all sccs are cut. Therefore remove in inter scc edges in FCG */
-                        if(i!=j) {
+                        if (i!=j) {
                             fcg->adj->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 0;
                         }
                     }
@@ -931,7 +929,7 @@ void update_fcg_between_sccs(Graph *fcg, int scc1, int scc2, PlutoProg *prog)
     }
 
     
-    if(options->scc_cluster) {
+    if (options->scc_cluster) {
         update_scc_cluster_fcg_between_sccs(fcg, scc1, scc2, prog);
         return;
     }
@@ -943,8 +941,8 @@ void update_fcg_between_sccs(Graph *fcg, int scc1, int scc2, PlutoProg *prog)
                         stmts[j]->trans->val[stmts[j]->trans->nrows-1][nvar + npar]) {
                     stmt_offset1 = ddg->vertices[i].fcg_stmt_offset;
                     stmt_offset2 = ddg->vertices[i].fcg_stmt_offset;
-                    for(k=0; k<stmts[i]->dim_orig; k++) {
-                        for(l=0; l<stmts[j]->dim_orig; l++) {
+                    for (k=0; k<stmts[i]->dim_orig; k++) {
+                        for (l=0; l<stmts[j]->dim_orig; l++) {
                             fcg->adj->val[stmt_offset1+k][stmt_offset2+l] = 0;
                             fcg->adj->val[stmt_offset2+l][stmt_offset1+k] = 0;
                         }
@@ -955,13 +953,13 @@ void update_fcg_between_sccs(Graph *fcg, int scc1, int scc2, PlutoProg *prog)
     } else {
         IF_DEBUG(printf("Updating FCG between SCCs%d and %d\n",scc1,scc2););
         for (i=0; i<nstmts; i++) {
-            for(j=0; j<nstmts; j++) {
+            for (j=0; j<nstmts; j++) {
                 if ((stmts[i]->scc_id >= scc2 && stmts[j]->scc_id<scc2) ||
                         (stmts[j]->scc_id>=scc2 && stmts[i]->scc_id < scc2)) {
                     stmt_offset1 = ddg->vertices[i].fcg_stmt_offset;
                     stmt_offset2 = ddg->vertices[j].fcg_stmt_offset;
-                    for(k=0; k<stmts[i]->dim_orig; k++) {
-                        for(l=0; l<stmts[j]->dim_orig; l++) {
+                    for (k=0; k<stmts[i]->dim_orig; k++) {
+                        for (l=0; l<stmts[j]->dim_orig; l++) {
                             fcg->adj->val[stmt_offset1+k][stmt_offset2+l] = 0;
                             fcg->adj->val[stmt_offset2+l][stmt_offset1+k] = 0;
                         }
@@ -1022,7 +1020,7 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
 
     if (options->fuse == TYPED_FUSE) {
         par_preventing_adj_mat = pluto_matrix_alloc (num_nodes, num_nodes);
-        for(i=0; i<num_nodes; i++) {
+        for (i=0; i<num_nodes; i++) {
             bzero(par_preventing_adj_mat->val[i], num_nodes*sizeof(int64));
         }
     }
@@ -1061,7 +1059,7 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
     
     /* Add premutation preventing intra statement dependence edges in the FCG.
      * These are self loops on vertices of the FCG. */ 
-    if(options->scc_cluster) {
+    if (options->scc_cluster) {
         fcg_scc_cluster_add_permute_preventing_edges(fcg, colour, prog, *conflicts, current_colour, obj);
     } else {
         add_permute_preventing_edges(fcg, colour, prog, *conflicts, current_colour, obj);
@@ -1174,7 +1172,7 @@ bool is_valid_colour(int v, int c, Graph *fcg, int * colour)
     int i, fcg_nVertices;
     fcg_nVertices = fcg->nVertices;
     for (i=0;i< fcg_nVertices;i++){
-        if((fcg->adj->val[i][v]==1||fcg->adj->val[v][i]==1) && colour[i]==c){
+        if ((fcg->adj->val[i][v]==1||fcg->adj->val[v][i]==1) && colour[i]==c){
             return false;
         }
     }
@@ -1186,7 +1184,7 @@ bool is_discarded(int v, int list[], int num)
 {
     int i;
     for (i=0; i<num; i++){
-        if(list[i]==v)
+        if (list[i]==v)
             return true;
     }
     return false;
@@ -1205,11 +1203,11 @@ int get_next_min_vertex(int fcg_stmt_offset, int stmt_id, int *list, int num, in
     stmts = prog->stmts;
     min = 0;
 
-    /* if(pv == -1){ */
+    /* if (pv == -1){ */
     /*     return min; */
     /* } */
     for (i=0; i<stmts[stmt_id]->dim_orig; i++) {
-        if(!is_discarded(fcg_stmt_offset+i, list, num)) {
+        if (!is_discarded(fcg_stmt_offset+i, list, num)) {
             if (options->lpcolour) {
                 scc_id = stmts[stmt_id]->scc_id;
                 sol = prog->ddg->sccs[scc_id].sol;
@@ -1255,21 +1253,21 @@ int* get_common_parallel_dims_for_sccs(Scc scc1, Scc scc2, PlutoProg *prog)
         }
     }
     printf ("Parallel sol for scc %d\n", scc1.id);
-    for(i=0;i<nvar;i++) {
+    for (i=0;i<nvar;i++) {
         printf ("c_%d: %d ", i, npar+1+stmt1*(nvar+1)+i);
     }
     printf("\n");
     printf ("Parallel sol for scc %d\n", scc2.id);
-    for(i=0;i<nvar;i++) {
+    for (i=0;i<nvar;i++) {
         printf ("c_%d: %d ", i, npar+1+stmt2*(nvar+1)+i);
     }
     printf("\n");
     stmt_offset = npar+1;
     for (i=0; i<nvar ; i++) {
-        if(stmts[stmt1]->is_orig_loop[i] && stmts[stmt2]->is_orig_loop[i]) {
-            if((scc1.sol[stmt_offset+stmt1*(nvar+1)+i] > 0.0f) 
+        if (stmts[stmt1]->is_orig_loop[i] && stmts[stmt2]->is_orig_loop[i]) {
+            if ((scc1.sol[stmt_offset+stmt1*(nvar+1)+i] > 0.0f) 
                     && (scc2.sol[stmt_offset+stmt2*(nvar+1)+i] > 0.0f)) {
-                if(parallel_dims == NULL) {
+                if (parallel_dims == NULL) {
                     parallel_dims = (int*) malloc (sizeof(int)*nvar);
                     bzero(parallel_dims, nvar*sizeof(int));
                 }
@@ -1370,9 +1368,9 @@ void cut_around_scc (int scc_id, PlutoProg *prog)
     ddg = prog->ddg;
     for (j=0;j<ddg->num_sccs; j++) {
         if (scc_id!=j) {
-            if((j < scc_id) && ddg_sccs_direct_connected(ddg,prog,j,scc_id)) {
+            if ((j < scc_id) && ddg_sccs_direct_connected(ddg,prog,j,scc_id)) {
                 IF_DEBUG(printf("[colour SCC]: Cutting between scc %d and %d\n",j,scc_id););
-                if(options->fuse == NO_FUSE) { 
+                if (options->fuse == NO_FUSE) { 
                     cut_all_sccs(prog,ddg);
                 } else {
                     cut_between_sccs(prog,ddg,j,scc_id);
@@ -1427,12 +1425,12 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
 
 
     /* ToDo: Check if this condition can really happen.  */
-    if(stmt_pos >= sccs[scc_id].size){
+    if (stmt_pos >= sccs[scc_id].size){
         return true;
     }
 
-    if(prog->coloured_dims >= sccs[scc_id].max_dim) {
-        if(prog->coloured_dims > sccs[scc_id].max_dim){
+    if (prog->coloured_dims >= sccs[scc_id].max_dim) {
+        if (prog->coloured_dims > sccs[scc_id].max_dim){
             return true;
         }
         IF_DEBUG(printf("[colour SCC]: All Dimensions of statment %d in SCC %d have been coloured\n", sccs[scc_id].vertices[stmt_pos], scc_id););
@@ -1442,10 +1440,10 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
          * the existing dependence */
 
         /* This is just for experimental purposes. The following if code can be removed if the assert never fails */
-        if(sccs[scc_id].size !=1 ){
+        if (sccs[scc_id].size !=1 ){
             printf("SCC %d has size %d\n", scc_id,sccs[scc_id].size);
             int i;
-            for(i=0;i<sccs[scc_id].size; i++){
+            for (i=0;i<sccs[scc_id].size; i++){
                 printf("S%d,",sccs[scc_id].vertices[i]);
             }
             printf("\n");
@@ -1455,9 +1453,9 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
         if (sccs[scc_id].size == 1) {
             for (j=0;j<ddg->num_sccs; j++) {
                 if (scc_id!=j) {
-                    if((j < scc_id) && ddg_sccs_direct_connected(ddg,prog,j,scc_id)) {
+                    if ((j < scc_id) && ddg_sccs_direct_connected(ddg,prog,j,scc_id)) {
                         IF_DEBUG(printf("[colour SCC]: Cutting between scc %d and %d\n",j,scc_id););
-                        if(options->fuse == NO_FUSE) { 
+                        if (options->fuse == NO_FUSE) { 
                             cut_all_sccs(prog,ddg);
                         } else {
                             cut_between_sccs(prog,ddg,j,scc_id);
@@ -1723,7 +1721,7 @@ bool colour_scc_cluster_greedy(int scc_id, int *colour, int current_colour, Plut
     bzero (parallel_dims, max_dim*sizeof(bool));
 
     num_parallel_dims = 0;
-    for(i=0; i<max_dim; i++) {
+    for (i=0; i<max_dim; i++) {
         if (colour[v+i]==0 && !fcg->adj->val[v+i][v+i] && !par_preventing_adj_mat->val[v+i][v+i] 
                 && is_valid_colour(v+i, current_colour, fcg, colour)) {
             parallel_dims[i] = true;
@@ -1791,7 +1789,7 @@ void cut_from_predecessor(int scc_id, PlutoProg* prog)
     Graph *ddg;
     ddg = prog->ddg;
     for (i=scc_id-1; i>=0; i--) {
-        if(ddg_sccs_direct_connected(ddg, prog, i, scc_id)) {
+        if (ddg_sccs_direct_connected(ddg, prog, i, scc_id)) {
             cut_between_sccs(prog, ddg, i, scc_id);
         }
     }
@@ -2053,7 +2051,7 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
             is_successful = colour_scc(i, colour, c, 0, -1, prog);
         }
         /* If colouring fails in the fist SCC */
-        if(!is_successful) {
+        if (!is_successful) {
             IF_DEBUG(printf("Unable to colour SCC %d\n",i););
 
             fcg = prog->fcg;
@@ -2116,7 +2114,7 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                             /* TODO: Update this call testing is done */
                             update_fcg_between_sccs(fcg, 0, 0, prog);
                         } else {
-                            for(j=prev_scc; j>=0; j--) {
+                            for (j=prev_scc; j>=0; j--) {
                                 if (ddg_sccs_direct_connected(ddg, prog, j, i)) {
 
                                     IF_DEBUG(printf("[colour_fcg_scc_based]:Cutting between SCC %d and %d\n",i,j););
@@ -2152,7 +2150,7 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
 
                     update_fcg_between_sccs(fcg, 0, 0, prog);
                 } else {
-                    for(j=prev_scc; j>=0; j--) {
+                    for (j=prev_scc; j>=0; j--) {
                         if (ddg_sccs_direct_connected(ddg, prog, j, i)) {
 
                             IF_DEBUG(printf("[colour_fcg_scc_based]:Cutting between SCC %d and %d\n",i,j););
@@ -2287,7 +2285,7 @@ void find_permutable_dimensions_scc_based(int *colour, PlutoProg *prog)
         }
 
         /* Do not update ddg or sccs if sccs are clustered. It will be updated when FCG is rebuilt */
-        if(!options->scc_cluster) {
+        if (!options->scc_cluster) {
             free_scc_vertices(ddg);
 
             /* You can update the DDG but do not update the FCG.  Doing otherwise will remove 
@@ -2445,13 +2443,13 @@ int scale_shift_permutations(PlutoProg *prog, int *colour, int c)
             /* if (options->varliberalize) { */
             /*     for (j=0; j<ndeps; j++) { */
             /*         #<{(| Check if it has to be c or c+1 |)}># */
-            /*         if(deps[j]->temp_across && c < deps[j]->fuse_depth  */
+            /*         if (deps[j]->temp_across && c < deps[j]->fuse_depth  */
             /*                 && pluto_domain_equality(stmts[deps[j]->src],stmts[deps[j]->dest])) { */
-            /*             for(k=0;k<nvar;k++) { */
-            /*                 if(sol[npar+1+(deps[j]->src)*(nvar+1)+k] != sol[npar+1+(deps[j]->dest)*(nvar+1)+k]) */
+            /*             for (k=0;k<nvar;k++) { */
+            /*                 if (sol[npar+1+(deps[j]->src)*(nvar+1)+k] != sol[npar+1+(deps[j]->dest)*(nvar+1)+k]) */
             /*                     break; */
             /*             } */
-            /*             if(k!=nvar || (sol[npar+1+(deps[j]->src)*(nvar+1)+nvar]!=sol[npar+1+(deps[j]->dest)*(nvar+1)+nvar])) { */
+            /*             if (k!=nvar || (sol[npar+1+(deps[j]->src)*(nvar+1)+nvar]!=sol[npar+1+(deps[j]->dest)*(nvar+1)+nvar])) { */
             /*                 printf("Cutting between SCCs to prevent illegal transformation with var-lib"); */
             /*                 cut_between_sccs(prog,ddg,stmts[deps[j]->src]->scc_id, stmts[deps[j]->dest]->scc_id); */
             /*             } */
@@ -2510,14 +2508,14 @@ bool get_negative_components(Dep *dep, bool *dims_with_neg_components, PlutoProg
     has_negative_comp = false;
     loop_dims = 0;
     for (i=0; i<prog->num_hyperplanes; i++){
-        if(hProps[i].type == H_SCALAR && i < level){
+        if (hProps[i].type == H_SCALAR && i < level){
             continue;
         }
-        if(hProps[i].type == H_LOOP && i < level){
+        if (hProps[i].type == H_LOOP && i < level){
             loop_dims++;
             continue;
         }
-        if(hProps[i].type == H_SCALAR && i >= level){
+        if (hProps[i].type == H_SCALAR && i >= level){
             continue;
         }
         if (dep->dirvec[i] == DEP_MINUS || dep->dirvec[i] == DEP_STAR ) {
@@ -2561,7 +2559,7 @@ bool* dims_to_be_skewed(PlutoProg *prog, int scc_id, bool *tile_preventing_deps,
         /* } */
       
         if (dep_is_satisfied(dep)) {
-            if(get_negative_components(dep,dims_with_neg_components, prog, level)){
+            if (get_negative_components(dep,dims_with_neg_components, prog, level)){
                 tile_preventing_deps[i] = 1;
             }
         }
@@ -2588,11 +2586,11 @@ bool* innermost_dep_satisfaction_dims(PlutoProg *prog, bool *tile_preventing_dep
         loop_dims = 0;
         if (tile_preventing_deps[i]) {
             /* Update this. Make src_dims to be the levels instead of dimensions. */
-            for(j=0; j<prog->num_hyperplanes; j++) {
+            for (j=0; j<prog->num_hyperplanes; j++) {
                 if (j == dep->satisfaction_level) {
                     break;
                 }
-                else if(hProps[j].type == H_LOOP) {
+                else if (hProps[j].type == H_LOOP) {
                     loop_dims++;
                 }
             }
@@ -2618,7 +2616,7 @@ PlutoConstraints *get_skewing_constraints(bool *src_dims, bool* skew_dims, int s
     assert (skewCst->ncols == CST_WIDTH);
     
     for (i=0; i<nstmts; i++) {
-        for(j=0; j<stmts[i]->dim_orig; j++){
+        for (j=0; j<stmts[i]->dim_orig; j++){
             if (src_dims[j] && stmts[i]->scc_id == scc_id) {
                 pluto_constraints_add_lb(skewCst, npar+1+ i*(nvar+1)+j, 1);
             }
@@ -2675,13 +2673,13 @@ void introduce_skew(PlutoProg *prog)
     orig_ddg = prog->ddg;
     prog->ddg = newDDG;
 
-    for(i=0; i<prog->ndeps; i++) {
+    for (i=0; i<prog->ndeps; i++) {
         tile_preventing_deps[i] = 0;
     }
 
     initial_cuts = 0;
     for (level = 0; level< prog->num_hyperplanes; level++) {
-        if(hProps[level].type == H_LOOP){
+        if (hProps[level].type == H_LOOP) {
             break;
         }
         initial_cuts ++; 
@@ -2689,7 +2687,7 @@ void introduce_skew(PlutoProg *prog)
     }
 
     /* Needed to handle the case when there are no loops  */
-    if(initial_cuts == prog->num_hyperplanes) {
+    if (initial_cuts == prog->num_hyperplanes) {
         return;
     }
     basecst = get_permutability_constraints(prog);
@@ -2725,8 +2723,8 @@ void introduce_skew(PlutoProg *prog)
             }
 
             int skew_dim = 0;
-            for(j=initial_cuts; j<prog->num_hyperplanes; j++) {
-                if(prog->hProps[j].type == H_LOOP && skew_dims[skew_dim] == 1) {
+            for (j=initial_cuts; j<prog->num_hyperplanes; j++) {
+                if (prog->hProps[j].type == H_LOOP && skew_dims[skew_dim] == 1) {
                     level = j;
                     break;
                 }
@@ -2745,7 +2743,7 @@ void introduce_skew(PlutoProg *prog)
 
             sol = pluto_prog_constraints_lexmin(skewingCst, prog);
 
-            if(sol){
+            if (sol) {
                 /* Set the Appropriate coeffs in the transformation matrix */
                 for (j=0; j<nstmts; j++) {
                     for (k = 0; k<nvar; k++){
@@ -2766,7 +2764,7 @@ void introduce_skew(PlutoProg *prog)
 
                 free(skew_dims);
 
-                if(level < prog->num_hyperplanes-1) {
+                if (level < prog->num_hyperplanes-1) {
                     skew_dims = dims_to_be_skewed(prog, i, tile_preventing_deps, level+1);
                     free(src_dims);
                     src_dims = innermost_dep_satisfaction_dims(prog, tile_preventing_deps);

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1254,16 +1254,7 @@ int* get_common_parallel_dims_for_sccs(Scc scc1, Scc scc2, PlutoProg *prog)
         }
     }
     assert((stmt1 >= 0) && (stmt2 >= 0));
-    /* printf ("Parallel sol for scc %d\n", scc1.id); */
-    /* for (i=0;i<nvar;i++) { */
-    /*     printf ("c_%d: %d ", i, npar+1+stmt1*(nvar+1)+i); */
-    /* } */
-    /* printf("\n"); */
-    /* printf ("Parallel sol for scc %d\n", scc2.id); */
-    /* for (i=0;i<nvar;i++) { */
-    /*     printf ("c_%d: %d ", i, npar+1+stmt2*(nvar+1)+i); */
-    /* } */
-    /* printf("\n"); */
+    
     stmt_offset = npar+1;
     for (i=0; i<nvar ; i++) {
         if (stmts[stmt1]->is_orig_loop[i] && stmts[stmt2]->is_orig_loop[i]) {

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -922,7 +922,7 @@ void update_fcg_between_sccs(Graph *fcg, int scc1, int scc2, PlutoProg *prog)
     ddg = prog->ddg;
     stmts = prog->stmts;
 
-    if (!options->fuse == TYPED_FUSE) {
+    if (!(options->fuse == TYPED_FUSE)) {
         /* This assertion might not hold in case of typed fuse */
         assert (fcg->to_be_rebuilt == false);
     }
@@ -2640,7 +2640,6 @@ bool constant_deps_in_scc(int scc_id, int level, PlutoConstraints *basecst, Plut
     int i,j,ndeps,nstmts,nvar,npar;
     Stmt **stmts;
     Dep **deps;
-    PlutoMatrix *obj;
 
     ndeps = prog->ndeps;
     nstmts = prog->nstmts;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1675,6 +1675,7 @@ int* rebuild_scc_cluster_fcg (PlutoProg *prog, int *colour, int c)
     }
 
     scc_colour = get_scc_colours_from_vertex_colours (prog, stmt_colour, c, nvertices);
+    pluto_matrix_free(par_preventing_adj_mat);
     prog->fcg = build_fusion_conflict_graph(prog, scc_colour, nvertices, c);
 
     /* These two have to be reset in the clustered apporoach as 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1688,11 +1688,14 @@ bool colour_scc_cluster_greedy(int scc_id, int *colour, int current_colour, Plut
         for (i=0; i<max_dim; i++) {
             if (parallel_dims[i]) {
                 colour[v+i] = current_colour;
+                IF_DEBUG(printf("[colour_scc_cluster_greedy] Dimension %d of SCC %d coloured with colour %d\n", i, scc_id, current_colour););
                 free (parallel_dims);
                 return true;
             }
         }
     }
+
+    printf("Scc %d has %d convex_successors \n", scc_id, num_convex_successors);
 
     common_dims = get_common_parallel_dims(scc_id, convex_successors, 
             num_convex_successors, colour, current_colour, parallel_dims, prog);
@@ -1701,12 +1704,14 @@ bool colour_scc_cluster_greedy(int scc_id, int *colour, int current_colour, Plut
         for (i=0; i<max_dim; i++) {
             if (parallel_dims[i]) {
                 colour[v+i] = current_colour;
+                IF_DEBUG(printf("[colour_scc_cluster_greedy] Dimension %d of SCC %d coloured with colour %d\n", i, scc_id, current_colour););
                 free (parallel_dims);
                 return true;
             }
         }
     }
     colour[v+colouring_dim] = current_colour;
+    IF_DEBUG(printf("[colour_scc_cluster_greedy] Dimension %d of SCC %d coloured with colour %d\n", i, scc_id, current_colour););
     colour_convex_successors(v+colouring_dim, convex_successors, num_convex_successors, colour, current_colour, prog);
     return true;
 }
@@ -1731,8 +1736,11 @@ bool colour_scc_cluster (int scc_id, int *colour, int current_colour, PlutoProg*
     }
 
     if (options->fuse == TYPED_FUSE && sccs[scc_id].is_parallel) {
+        printf("Scc %d has a parallel hyperplane\n", scc_id);
+        pluto_matrix_print(stdout, par_preventing_adj_mat);
         if (colour_scc_cluster_greedy(scc_id, colour, current_colour, prog)) {
             sccs[scc_id].has_parallel_hyperplane = true;
+            return true;
         } else {
             return false;
         }

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1609,6 +1609,7 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                     /* Sccs will be renumbered; hence all sccs have to be revisited; */
                     i=-1;
                     prev_scc = -1;
+                    continue;
                 } else {
                     prog->fcg = build_fusion_conflict_graph(prog, colour, fcg->nVertices, c);
                 }

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1414,12 +1414,12 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
         return true;
     }
 
-    if (options->scc_cluster) {
-        fcg_offset = ddg->sccs[scc_id].fcg_scc_offset;
-    } else {
-        stmt_id = sccs[scc_id].vertices[stmt_pos];
-        fcg_offset = ddg->vertices[stmt_id].fcg_stmt_offset;
-    }
+    /* if (options->scc_cluster) { */
+    /*     fcg_offset = ddg->sccs[scc_id].fcg_scc_offset; */
+    /* } else { */
+    stmt_id = sccs[scc_id].vertices[stmt_pos];
+    fcg_offset = ddg->vertices[stmt_id].fcg_stmt_offset;
+    /* } */
 
     while (num_discarded!=nvar) {
         j = get_next_min_vertex(fcg_offset, stmt_id, list, num_discarded, pv, prog);
@@ -1726,7 +1726,11 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                 IF_DEBUG( pluto_matrix_print(stdout, fcg->adj););
                 /* Needed only if it is not the first SCC */
                 if (i!=0) {
-                    is_distributed = colour_scc(i, colour, c, 0, -1, prog);
+                    if (options->scc_cluster) {
+                        is_distributed = colour_scc_cluster(i, colour, c, prog);
+                    } else {
+                        is_distributed = colour_scc(i, colour, c, 0, -1, prog);
+                    }
                     if (!is_distributed){
                         /* Colouring was prevented by a fusion preventing dependence. 
                          * Therefore cut DDG then update FCG and then colour */
@@ -1756,7 +1760,11 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
 
                         IF_DEBUG( printf("FCG after Updating \n"););
                         IF_DEBUG( pluto_matrix_print(stdout, fcg->adj););
-                        is_distributed = colour_scc(i,colour,c,0, -1, prog);
+                        if (options->scc_cluster) {
+                            is_distributed = colour_scc_cluster(i, colour, c, prog);
+                        } else {
+                            is_distributed = colour_scc(i,colour,c,0, -1, prog);
+                        }
                     }
                 } else {
                     /* If the colouring of first SCC had failed previously */ 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1305,7 +1305,6 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
     /* memset(list, -1, nvar); */
 
 
-    printf("Colouring SCC %d\n", scc_id);
 
     /* ToDo: Check if this condition can really happen.  */
     if(stmt_pos >= sccs[scc_id].size){
@@ -1383,7 +1382,11 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
 
     while (num_discarded!=nvar) {
         j = get_next_min_vertex(fcg_offset, stmt_id, list, num_discarded, pv, prog);
-        IF_DEBUG(printf("[Colour SCC] Trying Colouring dimension %d of statement %d with colour %d\n",j,stmt_id,c););
+        if (options->scc_cluster) {
+            IF_DEBUG(printf("[Colour SCC] Trying Colouring dimension %d of scc %d with colour %d\n",j,scc_id,c););
+        } else {
+            IF_DEBUG(printf("[Colour SCC] Trying Colouring dimension %d of statement %d with colour %d\n",j,stmt_id,c););
+        }
 
         v = fcg_offset+j;
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -469,6 +469,13 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                 /* Check for pairwise permutability of dimensions between scc1 and scc2 */
                 for (dim1=0; dim1<sccs[scc1].max_dim; dim1++) {
                     if (colour[scc1_fcg_offset+dim1] ==0 || colour[scc1_fcg_offset+dim1] == current_colour) {
+                        /* If there is a self edge on this vertex, then dont solve LP's. Just add edges to all dimensions of SCC2. */
+                        if (fcg->adj->val[scc1_fcg_offset+dim1][scc1_fcg_offset+dim1]==1) {
+                            for (dim2=0; dim2<sccs[scc2].max_dim; dim2++) {
+                                fcg->adj->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 1;
+                            }
+                            continue;
+                        }
                         /* Set lb of dim1 of each statement in Scc 1 */
                         for (i=0; i<sccs[scc1].size; i++) {
                             stmt1 = sccs[scc1].vertices[i];
@@ -481,6 +488,10 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                         for (dim2=0; dim2<sccs[scc2].max_dim; dim2++) {
                             /* Set the lower bounds of dimensions of each statement in SCC2 */
                             if (colour[scc2_fcg_offset+dim2] ==0 || colour[scc2_fcg_offset+dim2] == current_colour) {
+                                if (fcg->adj->val[scc2_fcg_offset+dim2][scc2_fcg_offset+dim2]==1) {
+                                    fcg->adj->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 1;
+                                    continue;
+                                }
                                 for (j=0; j<sccs[scc2].size; j++) {
                                     stmt2 = sccs[scc2].vertices[j];
                                     if(dim2<=stmts[stmt2]->dim_orig) {

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -2021,6 +2021,8 @@ int* rebuild_scc_cluster_fcg (PlutoProg *prog, int *colour, int c)
 
 }
 
+/* The routine checks if the two SCCs are fused in the till the current level.
+ * If yes it returns true else returns false */
 bool are_sccs_fused(PlutoProg *prog, int scc1, int scc2)
 {
     int i, num_hyperplanes, stmt1, stmt2, nvar, npar;
@@ -2049,6 +2051,10 @@ bool are_sccs_fused(PlutoProg *prog, int scc1, int scc2)
     return sccs_fused;
 }
 
+/* Routines adds a scalr hyperplane between two SCCs.
+ * Note that SCCs might not be connected. Ideally this routine
+ * can be moved to pluto.c (or framework.c) and approprite 
+ * changes can be made in DDG cut routines */
 void pluto_add_scalar_hyperplanes_between_sccs(PlutoProg *prog, int scc1, int scc2)
 {
     int i, j, nstmts, nvar, npar;
@@ -2636,6 +2642,11 @@ bool get_negative_components(Dep *dep, bool *dims_with_neg_components, PlutoProg
     return has_negative_comp;
 }
 
+/* Checks if there are any non constant dependences in the loop nest.
+ * This is done by computing \vec{d}.\vec{h} and the resultant \vec{u}
+ * has to be zero in pluto's cost function. Constraints to ensure u
+ * is zero is added and if the resulting LP formulation is unsat, then
+ * there are non constant deps in the SCC  */
 bool constant_deps_in_scc(int scc_id, int level, PlutoConstraints *basecst, PlutoProg *prog) {
     int i,j,ndeps,nstmts,nvar,npar;
     Stmt **stmts;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -987,6 +987,9 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
 
     if (options->fuse == TYPED_FUSE) {
         par_preventing_adj_mat = pluto_matrix_alloc (num_nodes, num_nodes);
+        for(i=0; i<num_nodes; i++) {
+            bzero(par_preventing_adj_mat->val[i], num_nodes*sizeof(int64));
+        }
     }
 
     boundcst = get_coeff_bounding_constraints(prog);
@@ -1031,7 +1034,7 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
 
     /* Add inter statement fusion and permute preventing edges.  */
 
-    if (options->fuse == TYPED_FUSE) {
+    if (options->fuse == TYPED_FUSE && !options->scc_cluster) {
         /* The lp solutions are found and the parallel sccs are marked. 
          * However marking is only used in parallel case of typed fuse only */
         mark_parallel_sccs(colour, prog);

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -311,6 +311,13 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
          * is because,even after satisfying the permute preventing dep, it might
          * still prevent fusion. */
         if (colour[fcg_offset1 + i] == 0 || colour[fcg_offset1 + i] == current_colour) {
+            if(fcg->adj->val[fcg_offset1+i][fcg_offset1+i]==1) {
+                /* Do not solve LPs if a dimenion of a statement is not permutable */
+                for(j=0;j<stmts[v2]->dim_orig; j++) {
+                    fcg->adj->val[fcg_offset1+i][fcg_offset2+j]=1;
+                }
+                continue;
+            }
 
             /* Set the lower bound of i^th dimension of v1 to 1 */
             conflictcst->val[row_offset + src_offset+i][CST_WIDTH-1] = -1;
@@ -318,6 +325,11 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
 
             for (j=0; j<stmts[v2]->dim_orig; j++) {
                 if (colour[fcg_offset2 + j] == 0 || colour[fcg_offset2 + j] == current_colour) {
+                    if(fcg->adj->val[fcg_offset1+i][fcg_offset1+i]==1) {
+                        fcg->adj->val[fcg_offset1+i][fcg_offset2+j]=1;
+                        continue;
+
+                    }
 
                     /* Set the lower bound of i^th dimension of v1 to 1 */
                     conflictcst->val[row_offset + dest_offset+j][CST_WIDTH-1] = -1;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1621,7 +1621,7 @@ bool colour_scc_cluster_greedy(int scc_id, int *colour, int current_colour, Plut
     Scc *sccs;
     int i,v,max_dim, num_convex_successors, num_parallel_dims;
     bool* parallel_dims;
-    int *convex_successors, *common_dims;
+    int *convex_successors, *common_dims, colouring_dim;
 
     ddg = prog->ddg;
     fcg = prog->fcg;
@@ -1637,7 +1637,7 @@ bool colour_scc_cluster_greedy(int scc_id, int *colour, int current_colour, Plut
 
     num_parallel_dims = 0;
     for(i=0; i<max_dim; i++) {
-        if (colour[v+i]==0 !fcg->adj->val[v+i][v+i] && !par_preventing_adj_mat->val[v+i][v+i] 
+        if (colour[v+i]==0 && !fcg->adj->val[v+i][v+i] && !par_preventing_adj_mat->val[v+i][v+i] 
                 && is_valid_colour(v+i, current_colour, fcg, colour)) {
             parallel_dims[i] = true;
             num_parallel_dims ++;
@@ -1663,7 +1663,7 @@ bool colour_scc_cluster_greedy(int scc_id, int *colour, int current_colour, Plut
     }
 
     common_dims = get_common_parallel_dims(scc_id, convex_successors, num_convex_successors, colour, current_colour, parallel_dims, prog);
-    colouring_dim = choose_colouring_dim(common_dims,max_dim);
+    colouring_dim = get_colouring_dim(common_dims,max_dim);
     if (colouring_dim == -1) {
         for (i=0; i<max_dim; i++) {
             if (parallel_dims[i]) {

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -447,6 +447,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                 row_offset = conflictcst->nrows-CST_WIDTH+1+inter_scc_constraints->nrows;
 
                 /* Add conflict constraints at the end of inter_scc_constraints */
+                /* pluto_constraints_cplex_print (stdout,conflictcst); */
                 pluto_constraints_add(inter_scc_constraints, conflictcst);
 
                 /* Set the shifting lb of coefficient for each statement in SCC1 to 0 */
@@ -478,8 +479,8 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                             stmt2 = sccs[scc2].vertices[j];
                             if(dim2<=stmts[stmt2]->dim_orig) {
                                 stmt2_offset = npar+1+(nvar+1)*stmt2;
-                                inter_scc_constraints->val[row_offset+stmt2_offset+dim1][CST_WIDTH-1] = -1;
-                                inter_scc_constraints->is_eq[row_offset+stmt2_offset+dim1] = 0;
+                                inter_scc_constraints->val[row_offset+stmt2_offset+dim2][CST_WIDTH-1] = -1;
+                                inter_scc_constraints->is_eq[row_offset+stmt2_offset+dim2] = 0;
                             }
                         }
                         /* Check if fusing ith dimesion of the source with ith dimension
@@ -493,7 +494,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                         /* If no solutions, then dimensions are not fusable. Add an edge in the conflict graph. */
                         if(sol == NULL)
                         {
-                            IF_DEBUG(printf("Unable to fuse Dimesnion %d of scc %d with dimension %d of scc %d \n",dim1,scc1 ,dim2 ,scc2););
+                            IF_DEBUG(printf("Unable to fuse dimension %d of scc %d with dimension %d of scc %d \n",dim1,scc1 ,dim2 ,scc2););
                             IF_DEBUG(printf(" Adding edge %d to %d in fcg\n",scc1_fcg_offset+dim1,scc2_fcg_offset+dim2););
                             fcg->adj->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 1;
                         } else {
@@ -511,8 +512,8 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                             stmt2 = sccs[scc2].vertices[j];
                             if(dim2<=stmts[stmt2]->dim_orig) {
                                 stmt2_offset = npar+1+(nvar+1)*stmt2;
-                                inter_scc_constraints->val[row_offset+stmt2_offset+dim1][CST_WIDTH-1] = 0;
-                                inter_scc_constraints->is_eq[row_offset+stmt2_offset+dim1] = 1;
+                                inter_scc_constraints->val[row_offset+stmt2_offset+dim2][CST_WIDTH-1] = 0;
+                                inter_scc_constraints->is_eq[row_offset+stmt2_offset+dim2] = 1;
                             }
                         }
                     }

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1635,6 +1635,7 @@ void colour_convex_successors(int k, int *convex_successors, int num_successors,
                     !par_preventing_adj_mat->val[v][v] && is_valid_colour (v, current_colour, fcg, colour)) {
                 colour[v] = current_colour;
                 sccs[scc_id].is_scc_coloured = true;
+                sccs[scc_id].has_parallel_hyperplane = true;
                 break;
             }
         }
@@ -1726,7 +1727,11 @@ bool colour_scc_cluster (int scc_id, int *colour, int current_colour, PlutoProg*
     }
 
     if (options->fuse == TYPED_FUSE && sccs[scc_id].is_parallel) {
-        return colour_scc_cluster_greedy(scc_id, colour, current_colour, prog);
+        if (colour_scc_cluster_greedy(scc_id, colour, current_colour, prog)) {
+            sccs[scc_id].has_parallel_hyperplane = true;
+        } else {
+            return false;
+        }
     } 
 
     scc_offset = prog->ddg->sccs[scc_id].fcg_scc_offset;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1314,7 +1314,7 @@ void cut_around_scc (int scc_id, PlutoProg *prog)
     int j;
     Graph *ddg;
     ddg = prog->ddg;
-    for (j=0;j<ddg->num_sccs; j++) {
+    for (j=0; j<ddg->num_sccs; j++) {
         if (scc_id!=j) {
             if ((j < scc_id) && ddg_sccs_direct_connected(ddg,prog,j,scc_id)) {
                 IF_DEBUG(printf("[colour SCC]: Cutting between scc %d and %d\n",j,scc_id););

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1458,6 +1458,7 @@ bool colour_scc_cluster (int scc_id, int *colour, int current_colour, PlutoProg*
         }
         if (is_valid_colour(v, current_colour, fcg, colour)) {
            colour[v] = current_colour; 
+            IF_DEBUG(printf("[Colour SCC] Colouring dimension %d of SCC %d  with colour %d\n",v-(ddg->sccs[scc_id].fcg_scc_offset),scc_id,colour[v]););
            return true;
         }
     }
@@ -1573,6 +1574,7 @@ int* rebuild_scc_cluster_fcg (PlutoProg *prog, int *colour, int c)
      * they will be revisited during colouring */
     prog->fcg->num_coloured_vertices = 0;
     prog->total_coloured_stmts[c-1] = 0;
+    prog->fcg->to_be_rebuilt = false;
 
     free (colour);
     free(stmt_colour);
@@ -1724,7 +1726,11 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                 IF_DEBUG(pluto_matrix_print(stdout, ddg->adj););
                 IF_DEBUG( printf("FCG after Updating \n"););
                 IF_DEBUG( pluto_matrix_print(stdout, fcg->adj););
-                is_distributed = colour_scc(i,colour,c,0, -1, prog);
+                if (options->scc_cluster) {
+                    is_distributed = colour_scc_cluster (i, colour, c, prog);
+                } else {
+                    is_distributed = colour_scc(i,colour,c,0, -1, prog);
+                }
             }
 
             /* Needed in case of partial satisfaction */
@@ -1747,7 +1753,11 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                 fcg = prog->fcg;
                 IF_DEBUG(printf("[Pluto]: Fcg After reconstruction\n"););
                 IF_DEBUG( pluto_matrix_print(stdout, fcg->adj););
-                is_distributed = colour_scc(i,colour,c,0, -1, prog);
+                if (options->scc_cluster) {
+                    is_distributed = colour_scc_cluster (i, colour, c, prog);
+                } else {
+                    is_distributed = colour_scc(i,colour,c,0, -1, prog);
+                }
 
             }
             assert (is_distributed == true);

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -38,7 +38,7 @@
 
 #if defined GLPK || defined GUROBI
 int scale_shift_permutations(PlutoProg *prog, int *colour, int c);
-double* pluto_fusion_constraints_feasibility_solve(PlutoConstraints *cst, PlutoMatrix *obj);
+double * pluto_fusion_constraints_feasibility_solve(PlutoConstraints *cst, PlutoMatrix *obj);
 bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg *prog);
 void pluto_print_colours(int *colour,PlutoProg *prog);
 PlutoMatrix *par_preventing_adj_mat;
@@ -91,10 +91,9 @@ PlutoConstraints* dfp_get_scc_ortho_constraints (int *colour, int scc_id, PlutoP
                 indcst->nrows ++;
             }
         } else {
-            q+= stmts[i]->dim_orig;
+            q += stmts[i]->dim_orig;
         }
         has_dim_to_be_coloured = false;
-
     }
     return indcst;
 }
@@ -355,7 +354,8 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
                     } else {
                         if (check_parallel) {
                             if (!is_lp_solution_parallel(sol,npar)) {
-                                IF_DEBUG(printf("Adding Parallelism preventing edge:%d to %d in fcg \n", fcg_offset1+i, fcg_offset2+j););
+                                IF_DEBUG(printf("Adding Parallelism preventing edge:%d to %d in fcg \n",
+                                            fcg_offset1+i, fcg_offset2+j););
                                 fcg->adj->val[fcg_offset1+i][fcg_offset2+j] = 1;
 
                             }
@@ -378,7 +378,7 @@ void fcg_add_pairwise_edges(Graph *fcg, int v1, int v2, PlutoProg *prog, int *co
     return;
 }
 
-/* Retruns both intra and inter dependence constraints for dependences between SCC1 and SCC2 */
+/* Returns both intra and inter dependence constraints for dependences between SCC1 and SCC2 */
 PlutoConstraints* get_inter_scc_dep_constraints (int scc1, int scc2, PlutoProg* prog)
 {
     int i, ndeps, src_stmt, dest_stmt;
@@ -411,7 +411,8 @@ PlutoConstraints* get_inter_scc_dep_constraints (int scc1, int scc2, PlutoProg* 
         dest_stmt = dep->dest;
         if ((stmts[src_stmt]->scc_id == scc1 || stmts[src_stmt]->scc_id == scc2) &&
                 (stmts[dest_stmt]->scc_id == scc1 || stmts[dest_stmt]->scc_id == scc2)) {
-            IF_DEBUG(printf("Computing Inter Scc deps for SCCs %d and %d: Dep: %d\n", stmts[src_stmt]->scc_id, stmts[dest_stmt]->scc_id, dep->id););
+            IF_DEBUG(printf("Computing Inter Scc deps for SCCs %d and %d: Dep: %d\n",
+                        stmts[src_stmt]->scc_id, stmts[dest_stmt]->scc_id, dep->id););
             if (dep->cst==NULL) {
                 compute_pairwise_permutability(dep,prog);
             }
@@ -428,7 +429,8 @@ PlutoConstraints* get_inter_scc_dep_constraints (int scc1, int scc2, PlutoProg* 
 
 /* Add inter SCC edges in the FCG in the clustered approach where
  * a vertex of the FCG corresponds to a dimension of a SCC */
-void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *prog, PlutoConstraints *conflictcst, int current_colour, PlutoMatrix* obj)
+void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *prog,
+        PlutoConstraints *conflictcst, int current_colour, PlutoMatrix* obj)
 {
     int i,j,num_sccs, scc1,scc2, row_offset, npar,nstmts, nvar, dim1, dim2;
     Graph *ddg;
@@ -486,7 +488,8 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                 /* Check for pairwise permutability of dimensions between scc1 and scc2 */
                 for (dim1=0; dim1<sccs[scc1].max_dim; dim1++) {
                     if (colour[scc1_fcg_offset+dim1] ==0 || colour[scc1_fcg_offset+dim1] == current_colour) {
-                        /* If there is a self edge on this vertex, then dont solve LP's. Just add edges to all dimensions of SCC2. */
+                        /* If there is a self edge on this vertex, then dont solve LP's. 
+                         * Just add edges to all dimensions of SCC2. */
                         if (fcg->adj->val[scc1_fcg_offset+dim1][scc1_fcg_offset+dim1]==1) {
                             for (dim2=0; dim2<sccs[scc2].max_dim; dim2++) {
                                 fcg->adj->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 1;
@@ -528,16 +531,14 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                                 /* If no solutions, then dimensions are not fusable. Add an edge in the conflict graph. */
                                 if (sol == NULL) {
                                     IF_DEBUG(printf("Unable to fuse dimension %d of scc %d with dimension %d of scc %d \n",dim1,scc1 ,dim2 ,scc2););
-                                    IF_DEBUG(printf(" Adding edge %d to %d in fcg\n",scc1_fcg_offset+dim1,scc2_fcg_offset+dim2););
+                                    IF_DEBUG(printf(" Adding edge %d to %d in fcg\n",
+                                                scc1_fcg_offset+dim1,scc2_fcg_offset+dim2););
                                     fcg->adj->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 1;
                                 } else {
                                     IF_DEBUG(printf("Able to fuse dimension %d of scc %d with dimension %d of scc %d \n",dim1,scc1 ,dim2 ,scc2););
-                                    if (check_parallel) {
-                                        if (!is_lp_solution_parallel(sol,npar)) {
-                                            IF_DEBUG(printf("Adding Parallelism preventing edge %d to %d in fcg \n", scc1_fcg_offset+dim1, scc2_fcg_offset+dim2););
-                                            par_preventing_adj_mat->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 1;
-
-                                        }
+                                    if (check_parallel && !is_lp_solution_parallel(sol,npar)) {
+                                        IF_DEBUG(printf("Adding Parallelism preventing edge %d to %d in fcg \n", scc1_fcg_offset+dim1, scc2_fcg_offset+dim2););
+                                        par_preventing_adj_mat->val[scc1_fcg_offset+dim1][scc2_fcg_offset+dim2] = 1;
                                     }
                                     free(sol);
                                 }
@@ -563,7 +564,6 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
                         }
                     }
                 }
-
                 pluto_constraints_free(inter_scc_constraints);
             }
         }
@@ -614,7 +614,6 @@ void compute_intra_stmt_deps(PlutoProg *prog)
             }
         }
     }
-
 }
 
 /* Computes dependence constraints for all dependences in the given SCC */
@@ -626,7 +625,6 @@ PlutoConstraints* compute_intra_scc_dep_cst(int scc_id, PlutoProg *prog)
     Stmt **stmts;
     PlutoConstraints *intra_scc_dep_cst = NULL;
 
-    
     deps = prog->deps;
     ndeps = prog->ndeps;
     stmts = prog->stmts;
@@ -636,10 +634,6 @@ PlutoConstraints* compute_intra_scc_dep_cst(int scc_id, PlutoProg *prog)
         if (options->rar ==0 && IS_RAR(dep->type)) {
             continue;
         }
-
-        /* if (options->varliberalize && dep->skipdep) {
-            continue;
-        } */
 
         if (dep_is_satisfied(dep)) {
             continue;
@@ -661,7 +655,6 @@ PlutoConstraints* compute_intra_scc_dep_cst(int scc_id, PlutoProg *prog)
             pluto_constraints_add(intra_scc_dep_cst, dep->cst);
         }
     }
-
     return intra_scc_dep_cst;
 }
 
@@ -669,8 +662,8 @@ PlutoConstraints* compute_intra_scc_dep_cst(int scc_id, PlutoProg *prog)
  * are added as self loops on FCG vertices. These vertices can not be coloured 
  * until the self loops are removed by reconstruction of the FCG.
  * Assumes that there are no loop shifts */
-
-void add_permute_preventing_edges(Graph* fcg, int *colour, PlutoProg *prog, PlutoConstraints* boundcst, int current_colour, PlutoMatrix *obj)
+void add_permute_preventing_edges(Graph* fcg, int *colour, PlutoProg *prog, 
+        PlutoConstraints* boundcst, int current_colour, PlutoMatrix *obj)
 {
     int nstmts,nvar,npar,i,j,stmt_offset,fcg_stmt_offset;
     int nrows;
@@ -681,11 +674,8 @@ void add_permute_preventing_edges(Graph* fcg, int *colour, PlutoProg *prog, Plut
     nstmts = prog->nstmts;
     nvar = prog->nvar;
     npar = prog->npar;
-
     stmts = prog->stmts;
-
     nrows = boundcst->nrows-CST_WIDTH+1;
-
 
     /* Compute the intra statment dependence constraints */
     compute_intra_stmt_deps(prog);
@@ -697,15 +687,13 @@ void add_permute_preventing_edges(Graph* fcg, int *colour, PlutoProg *prog, Plut
             coeff_bounds = pluto_constraints_alloc(1,CST_WIDTH);
             coeff_bounds->nrows = 0;
             coeff_bounds->ncols = CST_WIDTH;
+
             /* Add the intra statement dependence constraints and bounding constraints */
             intra_stmt_dep_cst = stmts[i]->intra_stmt_dep_cst;
-
             pluto_constraints_add(coeff_bounds,boundcst);
-
             pluto_constraints_add(coeff_bounds,intra_stmt_dep_cst);
 
             stmt_offset = (npar+1)+ i*(nvar+1);
-            /* coeff_bounds->val[0][CST_WIDTH-1] = -1; */
 
             for (j=0; j<stmts[i]->dim_orig; j++) {
                 if (colour[fcg_stmt_offset + j]==0 || colour[fcg_stmt_offset+j] == current_colour) {
@@ -742,61 +730,47 @@ void add_permute_preventing_edges(Graph* fcg, int *colour, PlutoProg *prog, Plut
  * are added as self loops on FCG vertices. These vertices can not be coloured 
  * until the self loops are removed by reconstruction of the FCG.
  * Assumes that there are no loop shifts */
-void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, PlutoProg *prog, PlutoConstraints* boundcst, int current_colour, PlutoMatrix *obj)
+void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, 
+        PlutoProg *prog, PlutoConstraints* boundcst, int current_colour, PlutoMatrix *obj)
 {
     int nstmts,nvar,npar,i,j,k, stmt_offset,fcg_scc_offset;
     int nrows, stmt_id;
     double *sol, tstart;
     Stmt **stmts;
     Scc *sccs;
-    
-
     int num_sccs;
     PlutoConstraints *intra_scc_dep_cst, *coeff_bounds;
 
     nstmts = prog->nstmts;
     nvar = prog->nvar;
     npar = prog->npar;
-
     stmts = prog->stmts;
     num_sccs=prog->ddg->num_sccs;
     sccs = prog->ddg->sccs;
-
     nrows = boundcst->nrows-CST_WIDTH+1;
 
-
-    /* Compute the intra statment dependence constraints */
-    /* compute_intra_stmt_deps(prog); */
-
-    /* fcg_stmt_offset = 0; */
+    /* Compute the intra Scc dependence constraints */
     for (i=0; i<num_sccs; i++) {
         sccs[i].is_parallel = 1;
         intra_scc_dep_cst = compute_intra_scc_dep_cst(i, prog);
-        /* pluto_constraints_cplex_print(stdout, intra_scc_dep_cst); */
-        /* printf("Bound constraints \n"); */
-        /* pluto_constraints_cplex_print(stdout,boundcst); */
+
         if (intra_scc_dep_cst!=NULL) {
             sccs[i].is_parallel = 0;
             /* Constraints to check permutability are added in the beginning */
             coeff_bounds = pluto_constraints_alloc(1,CST_WIDTH);
             coeff_bounds->nrows = 0;
             coeff_bounds->ncols = CST_WIDTH;
-            /* Add the intra statement dependence constraints and bounding constraints */
-            /* intra_stmt_dep_cst = stmts[i]->intra_stmt_dep_cst; */
 
-            /* Bound constraints have to be added first as these are modified while checking for permutability */
             pluto_constraints_add(coeff_bounds, boundcst);
 
             pluto_constraints_add(coeff_bounds,intra_scc_dep_cst);
-            /* printf("Coeff Boumnds\n"); */
-            /* pluto_constraints_cplex_print(stdout,coeff_bounds); */
 
             fcg_scc_offset = sccs[i].fcg_scc_offset;
-            /* stmt_offset = (npar+1)+ i*(nvar+1); */
 
             fcg_scc_offset = sccs[i].fcg_scc_offset;
             for (j=0; j<sccs[i].max_dim; j++) {
-                /* Check for permutability only if the current scc vertex in the fcg is not coloured or has the current colour */
+                /* Check for permutability only if the current scc vertex in the 
+                 * fcg is not coloured or has the current colour */
                 if (colour[fcg_scc_offset + j]==0 || colour[fcg_scc_offset+j] == current_colour) {
                     IF_DEBUG(printf("[Permute_preventing_edges]: Checking permutability of dimension %d of Scc %d \n",j,i););
                     /* Set the lower bounds of the jth coefficient for all the statments in scc i to 1. */
@@ -808,16 +782,13 @@ void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, Pluto
                             coeff_bounds->val[nrows+stmt_offset][CST_WIDTH-1] = -1;
                         }
                     }
-
-                    /* printf("Coeff Boumnds\n"); */
-                    /* pluto_constraints_cplex_print(stdout,coeff_bounds); */
                     prog->num_lp_calls++;
 
                     tstart = rtclock();
                     sol = pluto_fusion_constraints_feasibility_solve(coeff_bounds,obj);
                     prog->mipTime += rtclock()-tstart;
-                    /* If the constraints are infeasible then add a self edge in the FCG */
 
+                    /* If the constraints are infeasible then add a self edge in the FCG */
                     if (sol == NULL) {
                         IF_DEBUG(printf("Dimension %d of scc %d is not permutable\n",j,i););
                         fcg->adj->val[fcg_scc_offset+j][fcg_scc_offset+j] = 1;
@@ -847,7 +818,6 @@ void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, Pluto
             pluto_constraints_free(coeff_bounds);
         }
         pluto_constraints_free(intra_scc_dep_cst);
-        /* fcg_scc_offset += sccs[i].max_dim; */
     }
 }
 
@@ -932,12 +902,6 @@ void update_fcg_between_sccs(Graph *fcg, int scc1, int scc2, PlutoProg *prog)
         return;
     }
 
-    /* This has to be removed  */
-    /* if (!ddg_sccs_direct_connected(ddg,prog,scc1,scc2)) { */
-    /*     #<{(| printf("SCCs %d and %d not connected\n"); |)}># */
-    /*     return; */
-    /* } */
-    
     if (options->scc_cluster) {
         update_scc_cluster_fcg_between_sccs(fcg, scc1, scc2, prog);
         prog->fcg_update_time += rtclock() - tstart;
@@ -1037,15 +1001,12 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
 
     boundcst = get_coeff_bounding_constraints(prog);
 
-    /* t_start2 = rtclock(); */
-
     conflicts = (PlutoConstraints**)malloc(sizeof(PlutoConstraints*));
 
     /* The last CST_WIDTH-1 number of rows represent the bounds on the coeffcients  */
     *conflicts = pluto_constraints_alloc(CST_WIDTH-1 + boundcst->nrows,CST_WIDTH);
     (*conflicts)->ncols = CST_WIDTH;
 
-    
     obj = construct_cplex_objective(*conflicts, prog);
 
     pluto_constraints_add(*conflicts, boundcst);
@@ -1076,13 +1037,11 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
     }
 
     /* Add inter statement fusion and permute preventing edges.  */
-
     if (options->fuse == TYPED_FUSE && !options->scc_cluster) {
         /* The lp solutions are found and the parallel sccs are marked. 
          * However marking is only used in parallel case of typed fuse only */
         mark_parallel_sccs(colour, prog);
         IF_DEBUG(print_parallel_sccs(prog->ddg););
-
     }
 
     if (options->scc_cluster) {
@@ -1109,7 +1068,7 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
         fcg_add_intra_scc_edges(fcg,prog);
     } else {
         /* Add egdes between different dimensions of the same statement */
-        stmt_offset=0;
+        stmt_offset = 0;
         for (i=0; i<nstmts;i++) {
             for (j=stmt_offset; j<stmt_offset+stmts[i]->dim_orig; j++) {
                 fcg->vertices[j].fcg_stmt_offset = i;
@@ -1120,10 +1079,8 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
             }
             stmt_offset += stmts[i]->dim_orig;
 
-
             /* Remove the intra statement dependence constraints. Else the permutability constraints 
              * might be incorrect for rebuilding the fusion conflict graph.  */
-
             pluto_constraints_free(stmts[i]->intra_stmt_dep_cst);
             stmts[i]->intra_stmt_dep_cst = NULL;
         }
@@ -1141,9 +1098,6 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
     return fcg;
 }
 
-
-
-
 /******************  FCG Colouring Routines **********************************/
 
 /* Prints colour of each vertex of the FCG */
@@ -1157,13 +1111,12 @@ void pluto_print_colours(int *colour,PlutoProg *prog)
 
     stmt_offset = 0;
 
-
     if (options->scc_cluster) {
         for (i=0; i<prog->ddg->num_sccs;i++){
             for (j=0;j<prog->ddg->sccs[i].max_dim;j++){
                 printf("Colour of dimension %d of Scc %d: %d\n",j,i,colour[stmt_offset+j]);
             }
-            stmt_offset+=j;
+            stmt_offset += j;
         }
         return;
     }
@@ -1171,7 +1124,7 @@ void pluto_print_colours(int *colour,PlutoProg *prog)
         for (j=0;j<stmts[i]->dim_orig;j++){
             printf("Colour of Dimension %d of Stmt %d: %d\n",j,i,colour[stmt_offset+j]);
         }
-        stmt_offset+=j;
+        stmt_offset += j;
     }
 }
 
@@ -1181,8 +1134,8 @@ bool is_valid_colour(int v, int c, Graph *fcg, int * colour)
 {
     int i, fcg_nVertices;
     fcg_nVertices = fcg->nVertices;
-    for (i=0;i< fcg_nVertices;i++){
-        if ((fcg->adj->val[i][v]==1||fcg->adj->val[v][i]==1) && colour[i]==c){
+    for (i=0; i<fcg_nVertices; i++){
+        if ((fcg->adj->val[i][v]==1 || fcg->adj->val[v][i]==1) && colour[i]==c) {
             return false;
         }
     }
@@ -1200,7 +1153,6 @@ bool is_discarded(int v, int list[], int num)
     return false;
 }
 
-
 /* Routine that returns the next vertex to be coloured. Currently returns the next vertex in the ordered list. */
 int get_next_min_vertex(int fcg_stmt_offset, int stmt_id, int *list, int num, int pv, PlutoProg *prog){
     int i, min, npar, nvar, stmt_offset;
@@ -1213,9 +1165,6 @@ int get_next_min_vertex(int fcg_stmt_offset, int stmt_id, int *list, int num, in
     stmts = prog->stmts;
     min = 0;
 
-    /* if (pv == -1){ */
-    /*     return min; */
-    /* } */
     for (i=0; i<stmts[stmt_id]->dim_orig; i++) {
         if (!is_discarded(fcg_stmt_offset+i, list, num)) {
             if (options->lpcolour) {
@@ -1299,7 +1248,9 @@ bool is_convex_scc(int scc1, int scc2, Graph *ddg, PlutoProg * prog)
     return true;
 }
 
-
+/* The following routine isn't used anymore. Can be removed in future commits if found unnecessary. */
+/* Currently typedfuse is supported only with SCC clustering heuristics */
+#if 0
 /* In the unclustered approach this colouring heuristic chooses 
  * parallel hyperlanes to be found whenever they exist */
 bool colour_scc_from_lp_solution_with_parallelism (int scc_id, int *colour, PlutoProg *prog, int c)
@@ -1353,14 +1304,8 @@ bool colour_scc_from_lp_solution_with_parallelism (int scc_id, int *colour, Plut
 /* TODO: Fix this return statement after incorporating clustering heuristics */
    return false;
 
-    /* parallel_dims = (int*) malloc (sizeof(int)*nvar); */
-
-
-    /* for (i=0; i<ddg->sccs[i].size; i++) { */
-    /*    if ddg->vertices */
-    /* } */
-
 }
+#endif
 
 /* This cuts disconnects the SCC from the DDG by cutting all
  * the incoming and outgoing edges from the given scc */
@@ -1377,14 +1322,13 @@ void cut_around_scc (int scc_id, PlutoProg *prog)
                     cut_all_sccs(prog,ddg);
                 } else {
                     cut_between_sccs(prog,ddg,j,scc_id);
-                    /* cut_smart(prog,ddg); */
+
                     /* You also need to cut between a successor node as well */
                     for (j=scc_id+1; j<ddg->num_sccs; j++) {
                         if (ddg_sccs_direct_connected(ddg, prog, scc_id, j)) {
                             IF_DEBUG(printf("[colour SCC]: Cutting between scc %d and %d\n",scc_id,j););
-                            /* cut_between_sccs(prog, ddg, scc_id, j); */
-                            cut_all_sccs(prog, ddg);
-                            /* cut_smart(prog,ddg); */
+                            cut_between_sccs(prog, ddg, scc_id, j);
+                            /* cut_all_sccs(prog, ddg); */
                             break;
                         }
                     }
@@ -1399,17 +1343,16 @@ void cut_around_scc (int scc_id, PlutoProg *prog)
                 else {
                     cut_between_sccs(prog, ddg, scc_id, j);
                 }
-                /* cut_smart(prog,ddg); */
                 break;
             }
         }
     }
 }
+
 /* Colours the input SCC recursively.  The statement pos refers to the position 
  * of the statement in the list of vertices in the scc and pv refers to the 
  * previous vertex.  Returns true if the colouring is successful; 
  * else returns false.  */
-
 bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg *prog)
 {
     int j, v, fcg_offset, stmt_id, nvar;
@@ -1423,9 +1366,6 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
 
     int list[nvar];
     int num_discarded = 0;
-    /* memset(list, -1, nvar); */
-
-
 
     /* ToDo: Check if this condition can really happen.  */
     if (stmt_pos >= sccs[scc_id].size){
@@ -1442,7 +1382,8 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
          * between these scc's then cut between these scc's. The cut has to respect 
          * the existing dependence */
 
-        /* This is just for experimental purposes. The following if code can be removed if the assert never fails */
+        /* This is just for experimental purposes. The following if code can 
+         * be removed if the assert never fails */
         if (sccs[scc_id].size !=1 ){
             printf("SCC %d has size %d\n", scc_id,sccs[scc_id].size);
             int i;
@@ -1494,12 +1435,8 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
         return true;
     }
 
-    /* if (options->scc_cluster) { */
-    /*     fcg_offset = ddg->sccs[scc_id].fcg_scc_offset; */
-    /* } else { */
     stmt_id = sccs[scc_id].vertices[stmt_pos];
     fcg_offset = ddg->vertices[stmt_id].fcg_stmt_offset;
-    /* } */
 
     while (num_discarded!=nvar) {
         j = get_next_min_vertex(fcg_offset, stmt_id, list, num_discarded, pv, prog);
@@ -1547,7 +1484,7 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
             } else { 
                 list[num_discarded] = v;
                 num_discarded++;
-                IF_DEBUG(printf("[Colour SCC] Unable to Colour dimension %d of statement %d with colour %d\n",j,stmt_id,c););
+                IF_DEBUG(printf("[Colour SCC] Unable to colour dimension %d of statement %d with colour %d\n",j,stmt_id,c););
                 /* Undo the colouring. Try the next vertex. */
                 colour[v] = 0;
             }
@@ -1590,7 +1527,8 @@ bool is_colour_par_preventing (int v, int *colour, int current_colour)
 {
     int i;
     for (i=0; i<par_preventing_adj_mat->nrows; i++) {
-        if (colour[i]==current_colour && (par_preventing_adj_mat->val[v][i] || par_preventing_adj_mat->val[i][v])) {
+        if (colour[i]==current_colour && (par_preventing_adj_mat->val[v][i] 
+                    || par_preventing_adj_mat->val[i][v])) {
             return true;
         }
     }
@@ -1601,7 +1539,8 @@ bool is_colour_par_preventing (int v, int *colour, int current_colour)
  * can be coloured with a dimension of the current scc. 
  * A dimension is colourable if it is parallel and does 
  * not have a self edge in the FCG */
-int* get_common_parallel_dims(int scc_id, int* convex_successors, int num_convex_successors, int *colour, int current_colour, bool *is_colourable, PlutoProg *prog)
+int* get_common_parallel_dims(int scc_id, int* convex_successors, int num_convex_successors,
+        int *colour, int current_colour, bool *is_colourable, PlutoProg *prog)
 {
     int i, j, k, v;
     Graph *ddg, *fcg;
@@ -1630,7 +1569,8 @@ int* get_common_parallel_dims(int scc_id, int* convex_successors, int num_convex
                 if (colour[v]==0 && !fcg->adj->val[v][v] && ! is_adjecent(fcg, v, scc_offset+k) 
                         && is_valid_colour (v, current_colour, fcg, colour) && 
                         !par_preventing_adj_mat->val[v][v] && 
-                        !(par_preventing_adj_mat->val[v][scc_offset+k]|| par_preventing_adj_mat->val[scc_offset+k][v])) {
+                        !(par_preventing_adj_mat->val[v][scc_offset+k] || 
+                            par_preventing_adj_mat->val[scc_offset+k][v])) {
                     if (common_dims==NULL) {
                         common_dims = (int*) malloc (sizeof(int)*sccs[scc_id].max_dim);
                         bzero(common_dims, sccs[scc_id].max_dim*sizeof(int));
@@ -1775,7 +1715,6 @@ bool colour_scc_cluster_greedy(int scc_id, int *colour, int current_colour, Plut
     }
     colour[v+colouring_dim] = current_colour;
     IF_DEBUG(printf("[colour_scc_cluster_greedy] Dimension %d of SCC %d coloured with colour %d\n", colouring_dim, scc_id, current_colour););
-    /* printf("Colouring Convex Successors of SCC %d\n", scc_id); */
     colour_convex_successors(v+colouring_dim, convex_successors, num_convex_successors, colour, current_colour, prog);
     free(convex_successors);
     free(parallel_dims);
@@ -1818,9 +1757,9 @@ bool colour_scc_cluster (int scc_id, int *colour, int current_colour, PlutoProg*
         return true;
     }
 
-    /* printf("Colouring Scc %d with colour %d \n", scc_id, current_colour); */
     bool hybrid_cut = options->hybridcut && sccs[scc_id].has_parallel_hyperplane;
-    /* If the SCC has a parallel hyperplane and the fusion strategy is hybrid, then look max_fuse instead of greedy typed fuse heuristic */
+    /* If the SCC has a parallel hyperplane and the fusion strategy is hybrid, 
+     * then look max_fuse instead of greedy typed fuse heuristic */
     if (options->fuse == TYPED_FUSE && sccs[scc_id].is_parallel && !hybrid_cut ) {
         if (colour_scc_cluster_greedy(scc_id, colour, current_colour, prog)) {
             sccs[scc_id].has_parallel_hyperplane = true;
@@ -1874,20 +1813,7 @@ bool colour_scc_cluster (int scc_id, int *colour, int current_colour, PlutoProg*
         }
     }
     return false;
-
-    /* scc_offset = prog->ddg->sccs[scc_id].fcg_scc_offset; */
-    /* while (num_discarded != max_dim) { */
-    /*     v = get_next_min_cluster_vertex (scc_id, ddg); */
-    /*     if (colour[v]>0 && colour[v]!=c) { */
-    /*         IF_DEBUG(printf("[Colour SCC] Dimension %d of SCC %d already coloured with colour %d\n",v-(ddg->sccs[scc_id].fcg_scc_offset),scc_id,colour[v]);); */
-    /*         list[num_discarded] = v; */
-    /*         num_discarded++; */
-    /*         continue; */
-    /*     } */
-    /*  */
-    /* } */
 }
-
 
 /* Returns colours corresponding vertices of the original FCG 
  * from the colours of vertices of scc clustered FCG */
@@ -1922,7 +1848,8 @@ int* get_vertex_colour_from_scc_colour (PlutoProg *prog, int *colour, int* has_p
 /* Returns colours corresponding to clustered FCG from the colours of the statement. 
  * The routine picks the colour of the statement whose dimensionality is same as the 
  * dimensionality of the SCC as the colour of the SCC */
-int* get_scc_colours_from_vertex_colours (PlutoProg *prog, int *stmt_colour, int current_colour, int nvertices, int* has_parallel_hyperplane)
+int* get_scc_colours_from_vertex_colours (PlutoProg *prog, int *stmt_colour,
+        int current_colour, int nvertices, int* has_parallel_hyperplane)
 {
     int i, j, scc_offset, stmt_id;
     int nvar, num_sccs;
@@ -1999,7 +1926,8 @@ int* rebuild_scc_cluster_fcg (PlutoProg *prog, int *colour, int c)
         nvertices += prog->ddg->sccs[i].max_dim;
     }
 
-    scc_colour = get_scc_colours_from_vertex_colours (prog, stmt_colour, c, nvertices, has_parallel_hyperplane);
+    scc_colour = get_scc_colours_from_vertex_colours (prog, stmt_colour, c,
+            nvertices, has_parallel_hyperplane);
     if(options->fuse == TYPED_FUSE) {
         pluto_matrix_free(par_preventing_adj_mat);
     }
@@ -2017,7 +1945,6 @@ int* rebuild_scc_cluster_fcg (PlutoProg *prog, int *colour, int c)
     free(stmt_colour);
     free (has_parallel_hyperplane);
     return scc_colour;
-
 }
 
 /* The routine checks if the two SCCs are fused in the till the current level.
@@ -2076,11 +2003,10 @@ void pluto_add_scalar_hyperplanes_between_sccs(PlutoProg *prog, int scc1, int sc
         }else{
             stmts[i]->trans->val[stmts[i]->trans->nrows-1][nvar+npar] = 1;
         }
-
     }
 }
 
-/* Routine adds a hyperplane (H_LOOP) from the solution an ILP solution. 
+/* Adds a hyperplane (H_LOOP) from the solution an ILP solution. 
  * This method can also be moved to framework.c (or pluto.c) and 
  * appropriate changes can be made. */
 void add_hyperplane_from_ilp_solution (int64 *sol, PlutoProg *prog)
@@ -2112,7 +2038,6 @@ void add_hyperplane_from_ilp_solution (int64 *sol, PlutoProg *prog)
         stmt->hyp_types[stmt->trans->nrows-1] =
             pluto_is_hyperplane_scalar(stmt, stmt->trans->nrows-1)?
             H_SCALAR: H_LOOP;
-
     }
 }
 
@@ -2140,7 +2065,8 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
          * However, if some Sccs were previously coloured before the rebuilding the FCG, 
          * we dont have to re-colour those SCCs again. If fcg has to be rebuilt, 
          * then SCC ids would not have changed from previous clouring */
-        if (options->scc_cluster && prog->fcg->to_be_rebuilt == false && prog->ddg->sccs[i].is_scc_coloured) {
+        if (options->scc_cluster && prog->fcg->to_be_rebuilt == false 
+                && prog->ddg->sccs[i].is_scc_coloured) {
             fcg->num_coloured_vertices += ddg->sccs[i].max_dim;
             prog->total_coloured_stmts[c-1] += ddg->sccs[i].size;
             prev_scc = i;
@@ -2166,7 +2092,8 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                             pluto_add_scalar_hyperplanes_between_sccs(prog, prev_scc, i);
                         }
                     }
-                } else if (ddg->sccs[i].is_parallel && !hybrid_cut && !is_parallel_scc_coloured && prev_scc != -1) {
+                } else if (ddg->sccs[i].is_parallel && !hybrid_cut 
+                        && !is_parallel_scc_coloured && prev_scc != -1) {
                     if (are_sccs_fused(prog, prev_scc, i)) {
                         /* distribute the loops here. Note that
                          * sccs may not be connected at all. However we still
@@ -2192,8 +2119,8 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                 /* } */
             }
             is_successful = colour_scc_cluster (i, colour, c, prog);
-        } else if (options->fuse ==TYPED_FUSE && ddg->sccs[i].is_parallel) {
-            is_successful = colour_scc_from_lp_solution_with_parallelism(i, colour, prog, c);
+        /* } else if (options->fuse ==TYPED_FUSE && ddg->sccs[i].is_parallel) { */
+            /* is_successful = colour_scc_from_lp_solution_with_parallelism(i, colour, prog, c); */
         } else {
             is_successful = colour_scc(i, colour, c, 0, -1, prog);
         }
@@ -2358,7 +2285,6 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
         prev_scc = i;
         prog->fcg_colour_time += rtclock() - t_start;
     }
-
     return colour;
 }
 
@@ -2462,8 +2388,6 @@ void find_permutable_dimensions_scc_based(int *colour, PlutoProg *prog)
     if (options->fuse == TYPED_FUSE) {
         pluto_matrix_free(par_preventing_adj_mat);
     }
-
-
     return;
 }
 
@@ -2542,24 +2466,19 @@ int scale_shift_permutations(PlutoProg *prog, int *colour, int c)
     PlutoConstraints *basecst,*coeffcst, *boundcst;
     int64 *sol;
 
-
     nvar = prog->nvar;
     npar = prog->npar;
     nstmts = prog->nstmts;
-
 
     basecst = get_permutability_constraints(prog);
     assert (basecst->ncols == CST_WIDTH);
 
     boundcst = get_coeff_bounding_constraints(prog);
-    /* pluto_constraints_add(basecst,boundcst); */
-    /* pluto_constraints_free(boundcst); */
 
     coeffcst = pluto_constraints_alloc(basecst->nrows + boundcst->nrows + (nstmts*nvar), basecst->ncols);
     coeffcst->nrows = 0;
     coeffcst->ncols = basecst->ncols;
     assert (coeffcst->ncols == CST_WIDTH);
-
 
     IF_DEBUG(printf("Num stmts coloured with colour %d: %d\n", c+1, prog->total_coloured_stmts[c]););
 
@@ -2633,7 +2552,6 @@ int scale_shift_permutations(PlutoProg *prog, int *colour, int c)
             prog->scaling_cst_sol_time += rtclock()-t_start;
             return 0;
         }
-
     } else {
         IF_DEBUG(printf("Not All statements have been coloured\n"););
         pluto_constraints_free(coeffcst);
@@ -2691,7 +2609,6 @@ bool constant_deps_in_scc(int scc_id, int level, PlutoConstraints *basecst, Plut
     deps = prog->deps;
     stmts = prog->stmts;
 
-
     basecst->nrows = 0;
     basecst->ncols = CST_WIDTH;
     for (i=0; i<ndeps; i++) {
@@ -2712,17 +2629,13 @@ bool constant_deps_in_scc(int scc_id, int level, PlutoConstraints *basecst, Plut
             pluto_constraints_add_equality(basecst);
             basecst->val[basecst->nrows-1][npar+1+i*(nvar+1)+j] = 1;
             basecst->val[basecst->nrows-1][basecst->ncols -1] = -stmts[i]->trans->val[level][j];
-
         }
     }
     /* printf("Constraints for const dep check \n"); */
     /* pluto_constraints_cplex_print(stdout, basecst); */
     IF_DEBUG(pluto_constraints_cplex_print(stdout, basecst););
-    /* Replace this with LP call */
 
-    /* obj = construct_cplex_objective(basecst, prog);  */
-    /* double* sol = pluto_fusion_constraints_feasibility_solve(basecst, obj); */
-    /* pluto_matrix_free(obj); */
+    /* Replace this with LP call */
     int64* sol = pluto_prog_constraints_lexmin(basecst, prog);
     if (sol == NULL) {
         return false;
@@ -2737,7 +2650,6 @@ bool constant_deps_in_scc(int scc_id, int level, PlutoConstraints *basecst, Plut
 
 
 }
-
 
 /* Returns a boolean array in which the vales that are set represent 
  * the dimensions of the current SCC that have to be skewed in order 
@@ -2756,7 +2668,6 @@ bool* dims_to_be_skewed(PlutoProg *prog, int scc_id, bool *tile_preventing_deps,
     dims_with_neg_components = (bool*) malloc (nvar*sizeof(bool*));
     bzero(dims_with_neg_components, nvar*sizeof(bool));
 
-
     /* For each dep find whether it is satisfied by a cut or loop; */
     for (i=0; i<ndeps; i++) {
         dep = prog->deps[i];
@@ -2764,9 +2675,6 @@ bool* dims_to_be_skewed(PlutoProg *prog, int scc_id, bool *tile_preventing_deps,
             continue;
         if (!(stmts[dep->src]->scc_id == scc_id) || !(stmts[dep->dest]->scc_id ==scc_id))
             continue;
-        /* if (options->varliberalize && dep->skipdep) { */
-        /*     continue; */
-        /* } */
       
         if (dep_is_satisfied(dep)) {
             if (get_negative_components(dep,dims_with_neg_components, prog, level)){
@@ -2777,8 +2685,7 @@ bool* dims_to_be_skewed(PlutoProg *prog, int scc_id, bool *tile_preventing_deps,
     return dims_with_neg_components;
 }
 
-
-/* Returns the dimensions the satisfies the tiling preventing dependences */
+/* Returns the dimensions at which tiling preventing dependences are satisfied */
 bool* innermost_dep_satisfaction_dims(PlutoProg *prog, bool *tile_preventing_deps)
 {
     int i, j, ndeps, loop_dims;
@@ -2810,9 +2717,10 @@ bool* innermost_dep_satisfaction_dims(PlutoProg *prog, bool *tile_preventing_dep
     return sat_dim;
 }
 
-/* Returns skewing constraints. The lowerbounds of the 
- * dimensions that satisfy tile preventing dependences are set to 1 */
-PlutoConstraints *get_skewing_constraints(bool *src_dims, bool* skew_dims, int scc_id, PlutoProg* prog, int level, PlutoConstraints *skewCst)
+/* Returns skewing constraints. The lower bounds of the 
+ * dimensions that satisfy tiling preventing dependences are set to 1 */
+PlutoConstraints *get_skewing_constraints(bool *src_dims, bool* skew_dims,
+        int scc_id, PlutoProg* prog, int level, PlutoConstraints *skewCst)
 {
     int i, j, nvar, npar, nstmts;
     Stmt **stmts;
@@ -2832,7 +2740,7 @@ PlutoConstraints *get_skewing_constraints(bool *src_dims, bool* skew_dims, int s
             }
             else {
                 pluto_constraints_add_equality(skewCst);
-                skewCst->val[skewCst->nrows-1][npar+1+i*(nvar+1)+j]= 1;
+                skewCst->val[skewCst->nrows-1][npar+1+i*(nvar+1)+j] = 1;
                 /* Set the value of the current coeff to the one that you have already found */
                 skewCst->val[skewCst->nrows-1][CST_WIDTH-1] = -stmts[i]->trans->val[level][j];
             }
@@ -2842,7 +2750,7 @@ PlutoConstraints *get_skewing_constraints(bool *src_dims, bool* skew_dims, int s
     return skewCst;
 }
 
-/* Introduce Skewing Transformations if necessary: Called only when using the FCG based appraoch */
+/* Introduce loop skewing transformations if necessary */
 void introduce_skew(PlutoProg *prog)
 {
     int i, j, k, num_sccs, nvar, npar, nstmts, level,ndeps;
@@ -2854,7 +2762,6 @@ void introduce_skew(PlutoProg *prog)
     Stmt **stmts;
     bool *src_dims, *skew_dims, tile_preventing_deps[prog->ndeps];
     double tstart;
-
 
     nvar = prog->nvar;
     npar = prog->npar;
@@ -2915,7 +2822,6 @@ void introduce_skew(PlutoProg *prog)
     dep_satisfaction_update(prog,level);
     for (i =0; i<num_sccs; i++) {
         IF_DEBUG(printf("-------Looking for skews in SCC %d -----------------\n", i););
-
         /* dep_satisfaction_update(prog,level); */
         /* if (!constant_deps_in_scc(i, level, const_dep_check_cst, prog)) { */
         /*  */
@@ -2926,7 +2832,6 @@ void introduce_skew(PlutoProg *prog)
         skew_dims = dims_to_be_skewed(prog, i, tile_preventing_deps, level);
         src_dims = innermost_dep_satisfaction_dims(prog, tile_preventing_deps);
         level++;
-        
 
         for (; level <prog->num_hyperplanes; level++) {
             if (hProps[level].type != H_LOOP) {

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1583,7 +1583,8 @@ int* get_common_parallel_dims(int scc_id, int* convex_successors, int num_convex
                  * vertex j must be parallel and fusing with dimension k 
                  * must not hinder parallelism */
                 if (colour[v]==0 && !fcg->adj->val[v][v] && ! is_adjecent(fcg, v, scc_offset+k) 
-                        && is_valid_colour (v, current_colour, fcg, colour)) {
+                        && is_valid_colour (v, current_colour, fcg, colour) && 
+                        !par_preventing_adj_mat->val[v][v] && !par_preventing_adj_mat->val[v][k]) {
                     if (common_dims==NULL) {
                         common_dims = (int*) malloc (sizeof(int)*sccs[scc_id].max_dim);
                         bzero(common_dims, sccs[scc_id].max_dim*sizeof(int));
@@ -1615,7 +1616,7 @@ int get_colouring_dim(int *common_dims, int max_dim)
     }
     return dim;
 }
-void colour_convex_successors(int *convex_successors, int num_successors, int *colour, int current_colour, PlutoProg *prog)
+void colour_convex_successors(int k, int *convex_successors, int num_successors, int *colour, int current_colour, PlutoProg *prog)
 {
     Graph *fcg;
     Scc *sccs;
@@ -1630,7 +1631,7 @@ void colour_convex_successors(int *convex_successors, int num_successors, int *c
         scc_offset = sccs[scc_id].fcg_scc_offset;
         for (j=0;j<max_dim; j++) {
             v = scc_offset +j;
-            if (colour[v]==0 && !fcg->adj->val[v][v] && 
+            if (colour[v]==0 && !fcg->adj->val[v][v] && !par_preventing_adj_mat->val[v][k] &&
                     !par_preventing_adj_mat->val[v][v] && is_valid_colour (v, current_colour, fcg, colour)) {
                 colour[v] = current_colour;
                 sccs[scc_id].is_scc_coloured = true;
@@ -1701,7 +1702,7 @@ bool colour_scc_cluster_greedy(int scc_id, int *colour, int current_colour, Plut
         }
     }
     colour[v+colouring_dim] = current_colour;
-    colour_convex_successors(convex_successors, num_convex_successors, colour, current_colour, prog);
+    colour_convex_successors(v+colouring_dim, convex_successors, num_convex_successors, colour, current_colour, prog);
     return true;
 }
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1247,6 +1247,10 @@ bool is_convex_scc(int scc1, int scc2, Graph *ddg, PlutoProg * prog)
     int i;
     for (i=scc1+1; i<scc2; i++) {
         if (ddg_sccs_direct_connected(ddg, prog, i,scc2)) {
+            /* In case of typed fuse, this scc may have already been coloured */
+            if (options->fuse == TYPED_FUSE && sccs[i].is_scc_coloured) {
+                continue;
+            }
             printf("SCCs %d %d are not convex. %d is a predecessor of %d\n ", scc1,scc2,i,scc2);
             return false;
         }

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -539,7 +539,6 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
 
                 pluto_constraints_free(inter_scc_constraints);
             }
-
         }
     }
 }
@@ -1059,7 +1058,6 @@ Graph* build_fusion_conflict_graph(PlutoProg *prog, int *colour, int num_nodes, 
             (*conflicts)->is_eq[nrows + npar+1+i*(nvar+1)+nvar] = 1;
         }
     }
-    /* IF_DEBUG(printf("[Pluto] Build Fusion Conflict graph: FCG add parwise edges: %0.6lfs\n", rtclock()-t_start2);); */
 
     pluto_matrix_free(obj);
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1551,6 +1551,7 @@ int* get_vertex_colour_from_scc_colour (PlutoProg *prog, int *colour)
     sccs = prog->ddg->sccs;
 
     stmt_colour = (int*) malloc (nstmts*(nvar)*sizeof(int));
+    bzero(stmt_colour,nvar*nstmts*sizeof(int));
     for (i=0; i<nstmts; i++) {
         scc_id = stmts[i]->scc_id;
         scc_offset = sccs[scc_id].fcg_scc_offset;
@@ -1575,6 +1576,7 @@ int* get_scc_colours_from_vertex_colours (PlutoProg *prog, int *stmt_colour, int
     sccs = prog->ddg->sccs;
 
     scc_colour = (int*) malloc (nvertices*sizeof(int));
+    bzero(scc_colour,nvertices*sizeof(int));
 
     scc_offset = 0;
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -438,7 +438,7 @@ void fcg_scc_cluster_add_inter_scc_edges (Graph* fcg, int *colour, PlutoProg *pr
         scc1_fcg_offset = sccs[scc1].fcg_scc_offset;
         for (scc2=scc1+1; scc2<num_sccs; scc2++) {
             scc2_fcg_offset = sccs[scc2].fcg_scc_offset;
-            if(ddg_sccs_direct_connected(ddg, prog, scc1, scc2) || ddg_sccs_direct_connected (ddg, prog, scc2, scc1)) {
+            if(ddg_sccs_direct_connected(ddg, prog, scc1, scc2)) {
                 inter_scc_constraints = get_inter_scc_dep_constraints (scc1, scc2, prog);
                 if ((sccs[scc1].is_parallel || sccs[scc2].is_parallel) && options->fuse == TYPED_FUSE) {
                     check_parallel = true;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -2532,18 +2532,16 @@ void add_coeff_constraints_from_fcg_colouring (PlutoConstraints *coeffcst, int *
  * was successful. Else returns 0. */
 int scale_shift_permutations(PlutoProg *prog, int *colour, int c)
 {
-    int j, k, select;
+    int select;
     int nvar, npar;
     int nstmts;
     double t_start;
     PlutoConstraints *basecst,*coeffcst, *boundcst;
     int64 *sol;
 
-    Stmt **stmts;
 
     nvar = prog->nvar;
     npar = prog->npar;
-    stmts = prog->stmts;
     nstmts = prog->nstmts;
 
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1580,15 +1580,14 @@ int* get_scc_colours_from_vertex_colours (PlutoProg *prog, int *stmt_colour, int
     sccs = prog->ddg->sccs;
 
     scc_colour = (int*) malloc (nvertices*sizeof(int));
-    bzero(scc_colour,nvertices*sizeof(int));
+    bzero(scc_colour, nvertices*sizeof(int));
 
     scc_offset = 0;
 
     for (i=0; i<num_sccs; i++) {
         for (j=0; j<sccs[i].size; j++) {
             stmt_id = sccs[i].vertices[j];
-            if (sccs[i].max_dim == stmts[stmt_id]->dim)
-                break;
+            if (sccs[i].max_dim == stmts[stmt_id]->dim) break;
         }
 
         for (j=0; j<sccs[i].max_dim; j++) {

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -754,7 +754,7 @@ void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, Pluto
 
             /* stmt_offset = (npar+1)+ i*(nvar+1); */
 
-            fcg_scc_offset = 0;
+            fcg_scc_offset = sccs[i].fcg_scc_offset;
             for (j=0; j<sccs[i].max_dim; j++) {
 /* Todo: Update this check for the clustered routine once the colour array is fixed */
                 /* if (colour[fcg_stmt_offset + j]==0 || colour[fcg_stmt_offset+j] == current_colour) { */
@@ -762,7 +762,7 @@ void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, Pluto
                     /* Set the lower bounds of the jth coefficient for all the statments in scc i to 1. */
                     for (k=0; k<sccs[i].size; k++) {
                         stmt_id = sccs[i].vertices[k];
-                        if(j<=stmts[stmt_id]->dim_orig) {
+                        if(stmts[stmt_id]->is_orig_loop[j]) {
                             stmt_offset = npar+1+stmt_id*(nvar+1)+j;
                             coeff_bounds->is_eq[nrows+stmt_offset] = 0;
                             coeff_bounds->val[nrows+stmt_offset][CST_WIDTH-1] = -1;
@@ -799,7 +799,7 @@ void fcg_scc_cluster_add_permute_preventing_edges(Graph* fcg, int *colour, Pluto
             pluto_constraints_free(coeff_bounds);
         }
         free(intra_scc_dep_cst);
-        fcg_scc_offset += sccs[i].max_dim;
+        /* fcg_scc_offset += sccs[i].max_dim; */
     }
 }
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1504,6 +1504,15 @@ bool colour_scc_cluster (int scc_id, int *colour, int current_colour, PlutoProg*
             IF_DEBUG(printf("[Colour SCC] Dimension %d of SCC %d already coloured with colour %d\n",v-(ddg->sccs[scc_id].fcg_scc_offset),scc_id,colour[v]););
             continue;
         }
+
+        /* Cannot colour a vertex with a self edge. This is will not be 
+         * covered in the next case as the vertex v is not coloured in 
+         * the first place */
+        if (fcg->adj->val[v][v] == 1) {
+            continue;
+        }
+
+        /* Check if there is an adjecent vertex with the same colour */
         if (is_valid_colour(v, current_colour, fcg, colour)) {
            colour[v] = current_colour; 
             IF_DEBUG(printf("[Colour SCC] Colouring dimension %d of SCC %d  with colour %d\n",v-(ddg->sccs[scc_id].fcg_scc_offset),scc_id,colour[v]););
@@ -1872,7 +1881,6 @@ void find_permutable_dimensions_scc_based(int *colour, PlutoProg *prog)
 
         /* Recompute the SCC's in the updated DDG */
         ddg = prog->ddg;
-        IF_DEBUG(printf("[Find_permutable_dims_scc_based]: Updating SCCs \n"););
 
         if (options->lpcolour) {
             for (j=0; j<ddg->num_sccs; j++) {
@@ -1892,6 +1900,7 @@ void find_permutable_dimensions_scc_based(int *colour, PlutoProg *prog)
             ddg_update(ddg, prog);
             IF_DEBUG(printf("DDG after colouring with colour %d\n",i););
             IF_DEBUG(pluto_matrix_print(stdout, ddg->adj););
+            IF_DEBUG(printf("[Find_permutable_dims_scc_based]: Updating SCCs \n"););
             ddg_compute_scc(prog);
             compute_scc_vertices(ddg);
         }

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1583,7 +1583,7 @@ int* get_scc_colours_from_vertex_colours (PlutoProg *prog, int *stmt_colour, int
     for (i=0; i<num_sccs; i++) {
         for (j=0; j<sccs[i].size; j++) {
             stmt_id = sccs[i].vertices[j];
-            if (sccs[i].max_dim == stmts[j]->dim)
+            if (sccs[i].max_dim == stmts[stmt_id]->dim)
                 break;
         }
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1374,10 +1374,10 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
         return true;
     }
 
-    stmt_id = sccs[scc_id].vertices[stmt_pos];
     if (options->scc_cluster) {
         fcg_offset = ddg->sccs[scc_id].fcg_scc_offset;
     } else {
+        stmt_id = sccs[scc_id].vertices[stmt_pos];
         fcg_offset = ddg->vertices[stmt_id].fcg_stmt_offset;
     }
 
@@ -1421,7 +1421,7 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
             colour[v] = c;
             /* If this is a valid colour, then try colouring the next vertex in the SCC */
             if (colour_scc(scc_id, colour, c, stmt_pos+1, v, prog)) {
-                IF_DEBUG(printf("[Colour SCC]Colouring dimension %d of statement %d with colour %d\n",j,stmt_id,c););
+                IF_DEBUG(printf("[Colour SCC] Colouring dimension %d of statement %d with colour %d\n",j,stmt_id,c););
                 return true;
             } else { 
                 list[num_discarded] = v;
@@ -1835,18 +1835,18 @@ void add_coeff_constraints_from_scc_clustered_fcg_colouring (PlutoConstraints *c
     scc_offset = 0;
 
     for (j=0;j<num_sccs; j++) {
-        for (k=0; k<ddg->sccs[j].max_dim; k++) {
-            for (i=0;i<ddg->sccs[j].size; i++) {
-                stmt_id = ddg->sccs[j].vertices[i];
+        for (i=0;i<ddg->sccs[j].size; i++) {
+            stmt_id = ddg->sccs[j].vertices[i];
+            for (k=0; k<ddg->sccs[j].max_dim; k++) {
                 if (colour[scc_offset+k]==c && stmts[stmt_id]->is_orig_loop[k]) {
                     pluto_constraints_add_lb(coeffcst,npar+1+stmt_id*(nvar+1)+k,1);
                 } else {
                     pluto_constraints_add_equality(coeffcst);
-                    coeffcst->val[coeffcst->nrows-1][npar+1+j*(stmt_id+1)+k] = 1;
+                    coeffcst->val[coeffcst->nrows-1][npar+1+stmt_id*(nvar+1)+k] = 1;
                 }
             }
         }
-        scc_offset += k;
+        scc_offset += ddg->sccs[j].max_dim;
     }
 }
 

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1241,9 +1241,10 @@ int* get_common_parallel_dims_for_sccs(Scc scc1, Scc scc2, PlutoProg *prog)
     npar = prog->npar;
 
     stmt1 = -1;
+    stmt2 = -1;
     parallel_dims = NULL;
 
-    for (i=0; i<(scc1.size && stmt1 == -1); i++) {
+    for (i=0; (i<scc1.size) && (stmt1 == -1); i++) {
         for (j=0; j<scc2.size; j++) {
             if (is_adjecent(ddg, scc1.vertices[i], scc2.vertices[j])) {
                 stmt1 = scc1.vertices[i];
@@ -1252,16 +1253,17 @@ int* get_common_parallel_dims_for_sccs(Scc scc1, Scc scc2, PlutoProg *prog)
             }
         }
     }
-    printf ("Parallel sol for scc %d\n", scc1.id);
-    for (i=0;i<nvar;i++) {
-        printf ("c_%d: %d ", i, npar+1+stmt1*(nvar+1)+i);
-    }
-    printf("\n");
-    printf ("Parallel sol for scc %d\n", scc2.id);
-    for (i=0;i<nvar;i++) {
-        printf ("c_%d: %d ", i, npar+1+stmt2*(nvar+1)+i);
-    }
-    printf("\n");
+    assert((stmt1 >= 0) && (stmt2 >= 0));
+    /* printf ("Parallel sol for scc %d\n", scc1.id); */
+    /* for (i=0;i<nvar;i++) { */
+    /*     printf ("c_%d: %d ", i, npar+1+stmt1*(nvar+1)+i); */
+    /* } */
+    /* printf("\n"); */
+    /* printf ("Parallel sol for scc %d\n", scc2.id); */
+    /* for (i=0;i<nvar;i++) { */
+    /*     printf ("c_%d: %d ", i, npar+1+stmt2*(nvar+1)+i); */
+    /* } */
+    /* printf("\n"); */
     stmt_offset = npar+1;
     for (i=0; i<nvar ; i++) {
         if (stmts[stmt1]->is_orig_loop[i] && stmts[stmt2]->is_orig_loop[i]) {
@@ -1933,6 +1935,7 @@ int* get_scc_colours_from_vertex_colours (PlutoProg *prog, int *stmt_colour, int
     bzero(scc_colour, nvertices*sizeof(int));
 
     scc_offset = 0;
+    stmt_id = -1;
 
     for (i=0; i<num_sccs; i++) {
         sccs[i].is_scc_coloured = false;
@@ -1940,7 +1943,7 @@ int* get_scc_colours_from_vertex_colours (PlutoProg *prog, int *stmt_colour, int
             stmt_id = sccs[i].vertices[j];
             if (sccs[i].max_dim == stmts[stmt_id]->dim) break;
         }
-
+        assert (stmt_id >= 0);
         for (j=0; j<sccs[i].max_dim; j++) {
             if (stmt_colour[(stmt_id*nvar)+j] == current_colour) {
                 sccs[i].is_scc_coloured = true;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -921,7 +921,10 @@ void update_fcg_between_sccs(Graph *fcg, int scc1, int scc2, PlutoProg *prog)
     ddg = prog->ddg;
     stmts = prog->stmts;
 
-    assert (fcg->to_be_rebuilt == false);
+    if (!options->fuse == TYPED_FUSE) {
+        /* This assertion might not hold in case of typed fuse */
+        assert (fcg->to_be_rebuilt == false);
+    }
     tstart = rtclock();
 
     if (nstmts == 1) {
@@ -2098,11 +2101,9 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
         IF_DEBUG(printf("[colour_fcg_scc_based]: Colouring Scc %d of Size %d with colour %d\n",i,ddg->sccs[i].size, c););
         if (options->scc_cluster) {
             if (options->fuse == TYPED_FUSE) {
-                        printf("Analyzing SCC %d \n", i);
                 /* case when the previous scc that was coloured was parallel and the current one is seqential */
                 if (!ddg->sccs[i].is_parallel && is_parallel_scc_coloured) {
                     if (are_sccs_fused(prog, prev_scc, i)) {
-                        printf ("SCCs %d and %d are fused\n", prev_scc, i);
                         /* distribute the loops here. Note that
                          * sccs may not be connected at all. However we still
                          * need to cut to preserve parallelism */
@@ -2115,7 +2116,6 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                     }
                 } else if (ddg->sccs[i].is_parallel && !is_parallel_scc_coloured && prev_scc != -1) {
                     if (are_sccs_fused(prog, prev_scc, i)) {
-                        printf ("SCCs %d and %d are fused\n", prev_scc, i);
                         /* distribute the loops here. Note that
                          * sccs may not be connected at all. However we still
                          * need to cut to preserve parallelism */
@@ -2129,7 +2129,6 @@ int* colour_fcg_scc_based(int c, int *colour, PlutoProg *prog)
                 }
                 /* Set that a parallel SCC is being coloured */
                 if (ddg->sccs[i].is_parallel && !ddg->sccs[i].has_parallel_hyperplane) {
-                    printf ("Setting Parallel SCC while colouring SCC %d \n", i);
                     is_parallel_scc_coloured = true;
                 } else if (!ddg->sccs[i].is_parallel) {
                     is_parallel_scc_coloured = false;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1763,7 +1763,7 @@ bool colour_scc_cluster (int scc_id, int *colour, int current_colour, PlutoProg*
     }
 
     printf("Colouring Scc %d with colour %d \n", scc_id, current_colour);
-    if (options->fuse == TYPED_FUSE && sccs[scc_id].is_parallel) {
+    if (options->fuse == TYPED_FUSE && sccs[scc_id].is_parallel && !sccs[scc_id].has_parallel_hyperplane) {
         printf("Scc %d has a parallel hyperplane\n", scc_id);
         printf("Parallelism preventing adjecency Matrix\n");
         pluto_matrix_print(stdout, par_preventing_adj_mat);

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -2939,15 +2939,7 @@ void introduce_skew(PlutoProg *prog)
                     skew_dim++;
                 }
             }
-            printf("Skewing at level %d\n", level);
-            printf ("Src:dims\n");
-            for (j=0; j<nvar; j++) {
-                printf("%d : %d\n", j, src_dims[j]);
-            }
-            printf ("skew:dims\n");
-            for (j=0; j<nvar; j++) {
-                printf("%d : %d\n", j, skew_dims[j]);
-            }
+
             /* Skewing has to be done at level j+1 */
             if (j==prog->num_hyperplanes) {
                 break;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1609,6 +1609,9 @@ int get_colouring_dim(int *common_dims, int max_dim)
     int i, dim, max;
     max = 0;
     dim = -1;
+    if (common_dims == NULL) {
+        return dim;
+    }
     for (i=0;i<max_dim; i++) {
         if (common_dims[i] > max) {
             dim = i;
@@ -1616,6 +1619,7 @@ int get_colouring_dim(int *common_dims, int max_dim)
     }
     return dim;
 }
+
 void colour_convex_successors(int k, int *convex_successors, int num_successors, int *colour, int current_colour, PlutoProg *prog)
 {
     Graph *fcg;

--- a/src/framework-dfp.c
+++ b/src/framework-dfp.c
@@ -1333,9 +1333,9 @@ bool colour_scc(int scc_id, int *colour, int c, int stmt_pos, int pv, PlutoProg 
         }
         assert (sccs[scc_id].size ==1);
 
-        if(sccs[scc_id].size == 1){
-            for(j=0;j<ddg->num_sccs; j++){
-                if(scc_id!=j){
+        if (sccs[scc_id].size == 1) {
+            for (j=0;j<ddg->num_sccs; j++) {
+                if (scc_id!=j) {
                     if((j < scc_id) && ddg_sccs_direct_connected(ddg,prog,j,scc_id)) {
                         IF_DEBUG(printf("[colour SCC]: Cutting between scc %d and %d\n",j,scc_id););
                         if(options->fuse == NO_FUSE) { 

--- a/src/main.c
+++ b/src/main.c
@@ -95,6 +95,7 @@ void usage_message(void)
     fprintf(stdout, "       --maxfuse                 Maximal fusion\n");
     fprintf(stdout, "       --smartfuse [default]     Heuristic (in between nofuse and maxfuse)\n");
     fprintf(stdout, "       --typedfuse               Typed fusion. Fuses SCCs only when there is no loss of parallelism\n");
+    fprintf(stdout, "       --delayedcut              Delays the cut between SCCs of different dimensionalities in dfp approach\n");
     fprintf(stdout, "\n   Index Set Splitting        \n");
     fprintf(stdout, "       --iss                  \n");
     fprintf(stdout, "\n   Code generation       Options to control Cloog code generation\n");
@@ -176,6 +177,7 @@ int main(int argc, char *argv[])
         {"maxfuse", no_argument, &options->fuse, MAXIMAL_FUSE},
         {"smartfuse", no_argument, &options->fuse, SMART_FUSE},
         {"typedfuse", no_argument, &options->fuse, TYPED_FUSE},
+        {"delayedcut", no_argument, &options->delayed_cut,1},
         {"parallel", no_argument, &options->parallel, 1},
         {"parallelize", no_argument, &options->parallel, 1},
         {"innerpar", no_argument, &options->innerpar, 1},

--- a/src/main.c
+++ b/src/main.c
@@ -375,7 +375,9 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
     }
 #ifdef GLPK
     if (options->lp && !(options->glpk || options->gurobi)) {
+        if (!options->silent) {
         printf("[pluto] LP option available with a LP solver only. Using GLPK for lp solving\n");
+        }
         options->glpk = 1;
     }
 
@@ -385,8 +387,10 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
     }
         
     if (options->dfp && !(options->glpk || options->gurobi)) {
-        printf("[pluto] Dfp framework is currently supported with GLPK and Gurobi solvers.\n"); 
-        printf("[pluto] Using GLPK for constraint solving [default]. Use --gurobi to use Gurobi instead of GLPK.\n");
+        if (!options->silent) {
+            printf("[pluto] Dfp framework is currently supported with GLPK and Gurobi solvers.\n"); 
+            printf("[pluto] Using GLPK for constraint solving [default]. Use --gurobi to use Gurobi instead of GLPK.\n");
+        }
         options->glpk = 1;
     }
     if (options->glpk) {
@@ -412,9 +416,18 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
     }
 
     /* Make lastwriter default with dfp. This removes transitive dependences and hence reduces FCG construction time */
-    if (options->dfp) {
-        printf("[pluto] Enabling lastwriter dependence analysis with DFP\n");
+    if (options->dfp && !options->lastwriter) {
+        if (!options->silent) {
+            printf("[pluto] Enabling lastwriter dependence analysis with DFP\n");
+        }
         options->lastwriter = 1;
+    }
+    /* Typed fuse is available with clustered FCG approach only */
+    if (options->fuse ==TYPED_FUSE && options->dfp && !options->scc_cluster) {
+        if (!options->silent) {
+            printf("[pluto] Typed fuse supported only with clustered FCG approach. Turning on SCC clustering\n");
+        }
+        options->scc_cluster = 1;
     }
 
     /* Extract polyhedral representation */
@@ -685,7 +698,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
             /* printf("[pluto] \t\tTotal Scaling Constraints solve time: %0.6lfs\n", prog->scaling_cst_sol_time); */
             printf("[pluto] \t\tTotal Skewing time: %0.6lfs\n",prog->skew_time);
         }
-        printf("[pluto] \t\ttotal constraint solving time (LP/MIP/ILP) time: %0.6lfs\n", prog->mipTime);
+        printf("[pluto] \t\tTotal constraint solving time (LP/MIP/ILP) time: %0.6lfs\n", prog->mipTime);
         printf("[pluto] Code generation time: %0.6lfs\n", t_c);
         printf("[pluto] Other/Misc time: %0.6lfs\n", t_all-t_c-t_t-t_d);
         printf("[pluto] Total time: %0.6lfs\n", t_all);

--- a/src/main.c
+++ b/src/main.c
@@ -95,6 +95,7 @@ void usage_message(void)
     fprintf(stdout, "       --maxfuse                 Maximal fusion\n");
     fprintf(stdout, "       --smartfuse [default]     Heuristic (in between nofuse and maxfuse)\n");
     fprintf(stdout, "       --typedfuse               Typed fusion. Fuses SCCs only when there is no loss of parallelism\n");
+    fprintf(stdout, "       --hybridfuse              Typed fusion at outer levels and max fuse at inner level\n");
     fprintf(stdout, "       --delayedcut              Delays the cut between SCCs of different dimensionalities in dfp approach\n");
     fprintf(stdout, "\n   Index Set Splitting        \n");
     fprintf(stdout, "       --iss                  \n");
@@ -177,6 +178,7 @@ int main(int argc, char *argv[])
         {"maxfuse", no_argument, &options->fuse, MAXIMAL_FUSE},
         {"smartfuse", no_argument, &options->fuse, SMART_FUSE},
         {"typedfuse", no_argument, &options->fuse, TYPED_FUSE},
+        {"hybridfuse", no_argument, &options->hybridcut, 1},
         {"delayedcut", no_argument, &options->delayed_cut,1},
         {"parallel", no_argument, &options->parallel, 1},
         {"parallelize", no_argument, &options->parallel, 1},

--- a/src/main.c
+++ b/src/main.c
@@ -375,7 +375,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
     }
 #ifdef GLPK
     if (options->lp && !(options->glpk || options->gurobi)) {
-        printf("[pluto]: LP option available with a LP solver only. Using GLPK for lp solving\n");
+        printf("[pluto] LP option available with a LP solver only. Using GLPK for lp solving\n");
         options->glpk = 1;
     }
 
@@ -385,8 +385,8 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
     }
         
     if (options->dfp && !(options->glpk || options->gurobi)) {
-        printf("[pluto]: Dfp framework is currently supported with GLPK and Gurobi solvers.\n"); 
-        printf("[pluto]: Using GLPK for constraint solving [default]. Use --gurobi to use Gurobi instead of GLPK.\n");
+        printf("[pluto] Dfp framework is currently supported with GLPK and Gurobi solvers.\n"); 
+        printf("[pluto] Using GLPK for constraint solving [default]. Use --gurobi to use Gurobi instead of GLPK.\n");
         options->glpk = 1;
     }
     if (options->glpk) {
@@ -397,18 +397,24 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
 #endif
 
     if (options->dfp && !(options->glpk || options->gurobi)) {
-        printf ("[pluto]: ERROR: DFP framework is currently supported with GLPK or GUROBI solvers only. Run ./configure --help to for more information on using different solvers with Pluto.\n");
+        printf ("[pluto] ERROR: DFP framework is currently supported with GLPK or GUROBI solvers only. Run ./configure --help to for more information on using different solvers with Pluto.\n");
         pluto_options_free(options);
         usage_message();
         return 1;
     }
     if (options->scc_cluster && !options->dfp) {
-        printf("[pluto]: Warning: SCC clustering heuristics available with dfp option (FCG based approach) only. Disabling clustering \n");
+        printf("[pluto] Warning: SCC clustering heuristics available with dfp option (FCG based approach) only. Disabling clustering \n");
     }
 
     if (options->fuse == TYPED_FUSE && !options->dfp) {
         printf("[Pluto] WARNING: Typed Fuse Available with dfp framework only. Turning off Typed fuse\n");
         options->fuse = SMART_FUSE;
+    }
+
+    /* Make lastwriter default with dfp. This removes transitive dependences and hence reduces FCG construction time */
+    if (options->dfp) {
+        printf("[pluto] Enabling lastwriter dependence analysis with DFP\n");
+        options->lastwriter = 1;
     }
 
     /* Extract polyhedral representation */

--- a/src/main.c
+++ b/src/main.c
@@ -671,10 +671,10 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
         printf("\n[pluto] Timing statistics\n[pluto] SCoP extraction + dependence analysis time: %0.6lfs\n", t_d);
         printf("[pluto] Auto-transformation time: %0.6lfs\n", t_t);
         if (options-> dfp){
-            /* printf("[pluto] \t\ttotal FCG Construction Time: %0.6lfs\n", prog->fcg_const_time); */
-            /* printf("[pluto] \t\ttotal FCG Colouring Time: %0.6lfs\n", prog->fcg_colour_time); */
+            printf("[pluto] \t\tTotal FCG Construction Time: %0.6lfs\n", prog->fcg_const_time);
+            printf("[pluto] \t\tTotal FCG Colouring Time: %0.6lfs\n", prog->fcg_colour_time);
             /* printf("[pluto] \t\ttotal FCG Update Time: %0.6lfs\n", prog->fcg_update_time); */
-            printf("[pluto] \t\ttotal Permutation Black box time: %0.6lfs\n", prog->fcg_const_time+prog->fcg_colour_time+prog->fcg_colour_time);
+            /* printf("[pluto] \t\ttotal Permutation Black box time: %0.6lfs\n", prog->fcg_const_time + prog->fcg_colour_time); */
             printf("[pluto] \t\tTotal Scaling + Shifting time: %0.6lfs\n", prog->fcg_dims_scale_time);
             /* printf("[pluto] \t\tTotal Scaling Constraints solve time: %0.6lfs\n", prog->scaling_cst_sol_time); */
             printf("[pluto] \t\tTotal Skewing time: %0.6lfs\n",prog->skew_time);

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -1834,6 +1834,7 @@ int pluto_auto_transform(PlutoProg *prog)
         if (options->scc_cluster) {
             for (i=0; i<ddg->num_sccs; i++) {
                 ddg->sccs[i].fcg_scc_offset = nVertices;
+                ddg->sccs[i].is_scc_coloured = false;
                 nVertices += ddg->sccs[i].max_dim;
             }
         } else {

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -1878,6 +1878,7 @@ int pluto_auto_transform(PlutoProg *prog)
         /* This routine frees colour internally */
         find_permutable_dimensions_scc_based(colour, prog);
 
+
         if(!options->silent && options->debug) {
             printf("[Pluto]: Transformations before skewing \n");
             pluto_transformations_pretty_print(prog);
@@ -2207,7 +2208,7 @@ void ddg_compute_cc(PlutoProg *prog)
     graph_free(gU);
 }
 
-/* Compute the SCCs of a graph (usig Kosaraju's algorithm) */
+/* Compute the SCCs of a graph (using Kosaraju's algorithm) */
 void ddg_compute_scc(PlutoProg *prog)
 {
     int i;

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -1810,7 +1810,7 @@ int pluto_auto_transform(PlutoProg *prog)
                     num_ind_sols_found));
     }else{
         num_ind_sols_found = 0;
-        if (options->fuse == SMART_FUSE)    {
+        if (options->fuse == SMART_FUSE && !options->dfp)    {
             cut_scc_dim_based(prog,ddg);
         }
     }

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -328,7 +328,7 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
     /* Permute the constraints so that if all else is the same, the original
      * hyperplane order is preserved (no strong reason to do this) */
     /* We do not need to permute in case of pluto-lp-dfp */
-    if (!options->dfp){
+    if (!options->dfp) {
     j = npar + 1;
     for (i=0; i<nstmts; i++)    {
         for (k=j; k<j+(stmts[i]->dim_orig)/2; k++) {
@@ -403,7 +403,7 @@ int64 *pluto_prog_constraints_lexmin(PlutoConstraints *cst, PlutoProg *prog)
         int k1, k2, q;
         int64 tmp;
         /* Permute the solution in line with the permuted cst */
-        if(!options->dfp){
+        if (!options->dfp){
             j = npar + 1;
             for (i=0; i<nstmts; i++)    {
                 for (k=j; k<j+(stmts[i]->dim_orig)/2; k++) {
@@ -1822,7 +1822,7 @@ int pluto_auto_transform(PlutoProg *prog)
 
     if (options->dfp) {
 #if defined GLPK || defined GUROBI
-        if(options->fuse == NO_FUSE) {
+        if (options->fuse == NO_FUSE) {
             ddg_compute_scc(prog);
             cut_all_sccs(prog, ddg);
         }
@@ -1849,7 +1849,7 @@ int pluto_auto_transform(PlutoProg *prog)
         }
 
         colour = (int*) malloc(nVertices*sizeof(int));
-        for(i=0; i<nVertices;i++){
+        for (i=0; i<nVertices;i++){
             colour[i] = 0;
         }
 
@@ -1879,7 +1879,7 @@ int pluto_auto_transform(PlutoProg *prog)
         find_permutable_dimensions_scc_based(colour, prog);
 
 
-        if(!options->silent && options->debug) {
+        if (!options->silent && options->debug) {
             printf("[Pluto]: Transformations before skewing \n");
             pluto_transformations_pretty_print(prog);
         }
@@ -2005,10 +2005,10 @@ int pluto_auto_transform(PlutoProg *prog)
     }
 
  /* Deallocate the fusion conflict graph */
-    if (options->dfp){
+    if (options->dfp) {
 #if defined GLPK || defined GUROBI
         ddg = prog->ddg;
-        for(i=0; i<ddg->num_sccs; i++){
+        for (i=0; i<ddg->num_sccs; i++){
             free(ddg->sccs[i].vertices);
         }
         graph_free(prog->fcg);

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -1870,11 +1870,8 @@ int pluto_auto_transform(PlutoProg *prog)
             prog->scaled_dims[i] = 0;
         }
 
-        /* printf("[Pluto]: Num hyperplanes found so far %d\n", prog->num_hyperplanes); */
+        /* This routine frees colour internally */
         find_permutable_dimensions_scc_based(colour, prog);
-
-        IF_DEBUG(printf("[Pluto] Colouring Successful\n"););
-        IF_DEBUG(pluto_print_colours(colour,prog););
 
         if(!options->silent && options->debug) {
             printf("[Pluto]: Transformations before skewing \n");
@@ -1883,7 +1880,7 @@ int pluto_auto_transform(PlutoProg *prog)
 
         introduce_skew(prog);
 
-        free(colour);
+        /* free(colour); */
         free(prog->total_coloured_stmts);
         free(prog->scaled_dims);
 #endif

--- a/src/pluto.h
+++ b/src/pluto.h
@@ -457,6 +457,7 @@ Graph *ddg_create(PlutoProg *prog);
 int    ddg_sccs_direct_connected(Graph *g, PlutoProg *prog, int scc1, int scc2);
 int    cut_between_sccs(PlutoProg *prog, Graph *ddg, int scc1, int scc2);
 int    cut_all_sccs(PlutoProg *prog, Graph *ddg);
+void   cut_smart(PlutoProg *prog, Graph *ddg);
 
 void unroll_phis(PlutoProg *prog, int unroll_dim, int ufactor);
 

--- a/src/program.c
+++ b/src/program.c
@@ -2716,6 +2716,7 @@ PlutoOptions *pluto_options_alloc()
 
     /* Experimental */
     options->polyunroll = 0;
+    options->delayed_cut = 0;
 
     /* Default context is no context */
     options->codegen_context = -1;

--- a/src/program.c
+++ b/src/program.c
@@ -2717,6 +2717,7 @@ PlutoOptions *pluto_options_alloc()
     /* Experimental */
     options->polyunroll = 0;
     options->delayed_cut = 0;
+    options->hybridcut = 0;
 
     /* Default context is no context */
     options->codegen_context = -1;


### PR DESCRIPTION
 SCC clustering and typed fuse are enabled with pluto-lp-dfp with the options `--clusterscc` 
and `--typedfuse` respectively to `polycc`. `typedfuse` option enables `clusterscc` by default.