### PR TITLE
Add support for VPATH builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,8 +13,8 @@ MAY_ISL =
 # ISL_INCLUDE and ISL_LIBADD were already defined
 else
 MAY_ISL = isl
-ISL_INCLUDE += -I$(top_srcdir)/isl/include
-ISL_LIBADD += $(top_srcdir)/isl/libisl.la
+ISL_INCLUDE += -I$(top_srcdir)/isl/include -I$(top_builddir)/isl/include
+ISL_LIBADD += $(top_builddir)/isl/libisl.la
 endif
 
 
@@ -35,7 +35,7 @@ pkginclude_HEADERS = include/pluto/pluto.h include/pluto/matrix.h
 polycc: polycc.sh
 	rm -f polycc
 	echo "#! " $(BASH) > polycc
-	cat $(srcdir)/polycc.sh >> polycc
+	cat polycc.sh >> polycc
 	chmod ugo+x polycc
 
 .PHONY: bin binit
@@ -54,10 +54,10 @@ pclean:
 	$(MAKE) -C src clean
 
 test_libpluto: test/test_libpluto.c
-	libtool --mode=link --tag=CC $(CC) $(CLFAGS) $<  -Lsrc/.libs/ -I include $(ISL_INCLUDE) $(ISL_LIBADD) -I openscop/include -lpluto -lgomp -o test_libpluto
+	libtool --mode=link --tag=CC $(CC) $(CLFAGS) $<  -Lsrc/.libs/ -I $(top_srcdir)/include $(ISL_INCLUDE) $(ISL_LIBADD) -I openscop/include -lpluto -lgomp -o test_libpluto
 
 unit_tests: test/unit_tests.c
-	libtool --mode=link --tag=CC $(CC) $(CLFAGS) $< -Lsrc/.libs/ -I include -I src -lpluto -o unit_tests
+	libtool --mode=link --tag=CC $(CC) $(CLFAGS) $< -Lsrc/.libs/ -I $(top_srcdir)/include -I $(top_srcdir)/src -lpluto -o unit_tests
 
 src/pluto: force
 	$(MAKE) $(MFLAGS) -C src pluto

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,20 @@ AM_INIT_AUTOMAKE([foreign])
 AM_SILENT_RULES([yes])
 AM_CONFIG_HEADER(config.h)
 
+# Define REL_SRCDIR_PREFIX to be used when invoking configure script
+# of subprojects
+case $srcdir in
+  . )
+    REL_SRCDIR_PREFIX=..
+    ;;
+  [[\\/]]* | ?:[[\\/]]* )
+    REL_SRCDIR_PREFIX=$srcdir
+    ;;
+  *)
+    REL_SRCDIR_PREFIX=../$srcdir
+    ;;
+esac
+
 if test -n "${CXXFLAGS}"; then
   user_set_cxxflags=yes
 fi
@@ -72,9 +86,9 @@ AC_C_CONST
 
 AC_CHECK_HEADERS(math.h stdlib.h stdio.h assert.h string.h)
 
-dnl set SOURCE_DIR to current directory
-SOURCE_DIR=`pwd`
-AC_SUBST(SOURCE_DIR)
+dnl set BUILD_DIR to build directory
+BUILD_DIR=`pwd`
+AC_SUBST(BUILD_DIR)
 
 dnl Offer --with-clang-prefix
 AC_ARG_WITH(clang-prefix,
@@ -195,9 +209,10 @@ echo "=========================="
 configureopts="--with-gmp --with-bits=64 \
 --with-gmp-prefix=$GMP_PREFIX \
 --prefix=$prefix"
-(cd piplib/
+(mkdir -p piplib
+ cd piplib/
  $RM config.cache;
- ./configure ${configureopts} ${archopts}
+ $REL_SRCDIR_PREFIX/piplib/configure ${configureopts} ${archopts}
  )
 
 
@@ -209,8 +224,9 @@ echo "=========================="
 configureopts="--with-gmp=system \
 --with-gmp-prefix=$GMP_PREFIX \
 --prefix=$prefix"
-(cd openscop/
- ./configure ${configureopts} ${archopts}
+(mkdir -p openscop
+ cd openscop/
+ $REL_SRCDIR_PREFIX/openscop/configure ${configureopts} ${archopts}
  )
 
 
@@ -221,9 +237,10 @@ echo "Configuring Clan"
 echo "=========================="
 configureopts="--prefix=$prefix \
 --with-osl=build \
---with-osl-builddir=$SOURCE_DIR/openscop"
-(cd clan/
- ./configure ${configureopts} ${archopts}
+--with-osl-builddir=../openscop"
+(mkdir -p clan
+ cd clan/
+ $REL_SRCDIR_PREFIX/clan/configure ${configureopts} ${archopts}
  )
 
 dnl check if clan configure failed
@@ -240,11 +257,12 @@ echo "=========================="
 configureopts="--enable-llint-version \
 --prefix=$prefix \
 --with-piplib=build \
---with-piplib-builddir=$SOURCE_DIR/piplib \
+--with-piplib-builddir=../piplib \
 --with-osl=build \
---with-osl-builddir=$SOURCE_DIR/openscop"
-(cd candl/
- ./configure ${configureopts} ${archopts}
+--with-osl-builddir=../openscop"
+(mkdir -p candl
+ cd candl/
+ $REL_SRCDIR_PREFIX/candl/configure ${configureopts} ${archopts}
  )
 
 
@@ -255,8 +273,9 @@ echo "Configuring polylib"
 echo "======================"
 configureopts="--enable-longlongint-lib \
 --prefix=$prefix"
-(cd polylib/
- ./configure ${configureopts}
+(mkdir -p polylib
+ cd polylib/
+ $REL_SRCDIR_PREFIX/polylib/configure ${configureopts}
 )
 
 
@@ -289,8 +308,9 @@ configureopts="--with-gmp=system \
 --with-gmp-prefix=$GMP_PREFIX \
 --with-gmp-exec-prefix=$GMP_PREFIX \
 --prefix=$prefix"
-(cd isl/
- ./configure ${configureopts} ${archopts}
+(mkdir -p isl
+ cd isl/
+ $REL_SRCDIR_PREFIX/isl/configure ${configureopts} ${archopts}
 )
 fi
 
@@ -305,7 +325,8 @@ else
     configureopts="CXXFLAGS=-fno-rtti --with-isl-builddir=../isl --prefix=$prefix"
 fi
 
-(cd pet && ./configure ${configureopts})
+(mkdir -p pet
+ cd pet && $REL_SRCDIR_PREFIX/pet/configure ${configureopts})
 
 dnl check if pet configure had failed
 AC_CHECK_FILE([pet/Makefile], [], [AC_MSG_ERROR([configure in pet/ failed])])
@@ -317,11 +338,11 @@ echo "Configuring Cloog-isl"
 echo "=========================="
 if test x$external_isl = xfalse; then
 configureopts="--with-isl=build \
---with-isl-builddir=$SOURCE_DIR/isl \
+--with-isl-builddir=../isl \
 --with-gmp=system \
 --with-gmp-prefix=$GMP_PREFIX \
 --with-osl=build \
---with-osl-builddir=$SOURCE_DIR/openscop \
+--with-osl-builddir=../openscop \
 --prefix=$prefix"
 else
 configureopts="--with-isl=system \
@@ -329,16 +350,18 @@ configureopts="--with-isl=system \
 --with-gmp=system \
 --with-gmp-prefix=$GMP_PREFIX \
 --with-osl=build \
---with-osl-builddir=$SOURCE_DIR/openscop \
+--with-osl-builddir=../openscop \
 --prefix=$prefix"
 fi
-(cd cloog-isl/
- ./configure ${configureopts} ${archopts}
+(mkdir -p cloog-isl
+ cd cloog-isl/
+ $REL_SRCDIR_PREFIX/cloog-isl/configure ${configureopts} ${archopts}
  )
 
 AC_PATH_PROGS(BASH, bash)
 
 AC_CONFIG_FILES([getversion.sh], [chmod +x ./getversion.sh])
+AC_CONFIG_FILES([test.sh], [chmod +x ./test.sh])
 AC_CONFIG_COMMANDS([version.h],
                    [echo '#define PLUTO_VERSION "'`./getversion.sh`'"' > src/version.h])
 

--- a/polycc.sh.in
+++ b/polycc.sh.in
@@ -12,9 +12,10 @@
 # Available under GNU GPL version 3 or (at your option) any later version
 # 
 
-pluto=@SOURCE_DIR@/src/pluto
-plann=@SOURCE_DIR@/plann
-plorc=@SOURCE_DIR@/plorc
+pluto=@top_builddir@/src/pluto
+plann=@top_srcdir@/plann
+plorc=@top_srcdir@/plorc
+inscop=@top_srcdir@/inscop
 
 # Some additional setup here to ensure that variables are visible outside of the run function
 SOURCEFILE=""
@@ -65,16 +66,16 @@ PLUTOOUT=$OUTFILE
 
 # generate and insert unrolling annotations, run ancc on it,
 if [ "$UNROLL" == 1 ]; then
-    $plorc $PLUTOOUT @SOURCE_DIR@/orio-0.1.0
+    $plorc $PLUTOOUT @srcdir@/orio-0.1.0
 fi
 
 #if [ "$UNROLL" == 1 ]; then
-    #$plann $PLUTOOUT @SOURCE_DIR@/annotations
+    #$plann $PLUTOOUT @srcdir@/annotations
 #fi
 
 
 # put the original skeleton around the transformed code
-@SOURCE_DIR@/inscop $SOURCEFILE $OUTFILE $OUTFILE
+$inscop $SOURCEFILE $OUTFILE $OUTFILE
 
 if [ "$INDENT" == 1 ] && [ -x /usr/bin/clang-format ]; then
     clang-format --style=LLVM -i $OUTFILE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,8 +9,8 @@ MAINTAINERCLEANFILES = Makefile.in
 if EXTERNAL_ISL
 # ISL_INCLUDE, ISL_LIBADD were already defined
 else
-ISL_INCLUDE += -I$(top_srcdir)/isl/include
-ISL_LIBADD += $(top_srcdir)/isl/libisl.la
+ISL_INCLUDE += -I$(top_srcdir)/isl/include -I$(top_builddir)/isl/include
+ISL_LIBADD += $(top_builddir)/isl/libisl.la
 endif
 
 bin_PROGRAMS = pluto
@@ -55,14 +55,20 @@ pluto_SOURCES = \
 pluto_CXXFLAGS = $(OPT_FLAGS) $(DEBUG_FLAGS) \
    -DSCOPLIB_INT_T_IS_LONGLONG -DCLOOG_INT_GMP -DPLUTO_OPENCL \
    -I../include \
-   -I../piplib/include \
+   -I$(top_srcdir)/include \
+   -I$(top_srcdir)/piplib/include \
    -I../clan/include \
-   -I../pet/include \
+   -I$(top_srcdir)/clan/include \
+   -I$(top_srcdir)/pet/include \
    $(ISL_INCLUDE) \
    -I../cloog-isl/include \
+   -I$(top_srcdir)/cloog-isl/include \
    -I../openscop/include \
+   -I$(top_srcdir)/openscop/include \
    -I../candl/include \
-   -I../polylib/include
+   -I$(top_srcdir)/candl/include \
+   -I../polylib/include \
+   -I$(top_srcdir)/polylib/include
 # To avoid same name object from being created with libtool and without it.
 pluto_CFLAGS = $(AM_CFLAGS) $(pluto_CXXFLAGS)
 
@@ -111,7 +117,9 @@ libpluto_la_SOURCES = \
 libpluto_la_CXXFLAGS = $(OPT_FLAGS) $(DEBUG_FLAGS) \
    -DLIB_PLUTO -DSCOPLIB_INT_T_IS_LONGLONG -DCLOOG_INT_GMP \
    -I../include \
+   -I$(top_srcdir)/include \
    -I../piplib/include \
+   -I$(top_srcdir)/piplib/include \
    $(ISL_INCLUDE)
 # To avoid same name object from being created with libtool and without it.
 libpluto_la_CFLAGS = $(AM_CFLAGS) $(libpluto_la_CXXFLAGS)

--- a/test.sh.in
+++ b/test.sh.in
@@ -18,50 +18,50 @@ fi
 }
 
 TESTS="\
-  test/1dloop-invar.c \
-  test/costfunc.c \
-  test/doitgen.c \
-  test/fdtd-2d.c \
-  test/fusion1.c \
-  test/fusion2.c \
-  test/fusion3.c \
-  test/fusion4.c \
-  test/fusion5.c \
-  test/fusion6.c \
-  test/fusion7.c \
-  test/fusion8.c \
-  test/fusion9.c \
-  test/fusion10.c \
-  test/gemver.c \
-  test/jacobi-1d-imper.c \
-  test/jacobi-2d-imper.c \
-  test/intratileopt1.c \
-  test/intratileopt2.c \
-  test/intratileopt3.c \
-  test/intratileopt4.c \
-  test/matmul.c \
-  test/matmul-seq.c \
-  test/matmul-seq3.c \
-  test/multi-loop-param.c \
-  test/multi-stmt-stencil-seq.c \
-  test/mvt.c \
-  test/mxv.c \
-  test/mxv-seq.c \
-  test/mxv-seq3.c \
-  test/negparam.c \
-  test/nodep.c \
-  test/noloop.c \
-  test/polynomial.c \
-  test/seidel.c \
-  test/seq.c \
-  test/shift.c \
-  test/spatial.c \
-  test/tce-4index-transform.c \
-  test/tricky1.c \
-  test/tricky2.c \
-  test/tricky3.c \
-  test/tricky4.c \
-  test/wavefront.c \
+  @top_srcdir@/test/1dloop-invar.c \
+  @top_srcdir@/test/costfunc.c \
+  @top_srcdir@/test/doitgen.c \
+  @top_srcdir@/test/fdtd-2d.c \
+  @top_srcdir@/test/fusion1.c \
+  @top_srcdir@/test/fusion2.c \
+  @top_srcdir@/test/fusion3.c \
+  @top_srcdir@/test/fusion4.c \
+  @top_srcdir@/test/fusion5.c \
+  @top_srcdir@/test/fusion6.c \
+  @top_srcdir@/test/fusion7.c \
+  @top_srcdir@/test/fusion8.c \
+  @top_srcdir@/test/fusion9.c \
+  @top_srcdir@/test/fusion10.c \
+  @top_srcdir@/test/gemver.c \
+  @top_srcdir@/test/jacobi-1d-imper.c \
+  @top_srcdir@/test/jacobi-2d-imper.c \
+  @top_srcdir@/test/intratileopt1.c \
+  @top_srcdir@/test/intratileopt2.c \
+  @top_srcdir@/test/intratileopt3.c \
+  @top_srcdir@/test/intratileopt4.c \
+  @top_srcdir@/test/matmul.c \
+  @top_srcdir@/test/matmul-seq.c \
+  @top_srcdir@/test/matmul-seq3.c \
+  @top_srcdir@/test/multi-loop-param.c \
+  @top_srcdir@/test/multi-stmt-stencil-seq.c \
+  @top_srcdir@/test/mvt.c \
+  @top_srcdir@/test/mxv.c \
+  @top_srcdir@/test/mxv-seq.c \
+  @top_srcdir@/test/mxv-seq3.c \
+  @top_srcdir@/test/negparam.c \
+  @top_srcdir@/test/nodep.c \
+  @top_srcdir@/test/noloop.c \
+  @top_srcdir@/test/polynomial.c \
+  @top_srcdir@/test/seidel.c \
+  @top_srcdir@/test/seq.c \
+  @top_srcdir@/test/shift.c \
+  @top_srcdir@/test/spatial.c \
+  @top_srcdir@/test/tce-4index-transform.c \
+  @top_srcdir@/test/tricky1.c \
+  @top_srcdir@/test/tricky2.c \
+  @top_srcdir@/test/tricky3.c \
+  @top_srcdir@/test/tricky4.c \
+  @top_srcdir@/test/wavefront.c \
   "
 # Tests without --pet and without any tiling and parallelization.
 for file in $TESTS; do
@@ -72,14 +72,14 @@ done
 
 # Test per cc objective
 printf '%-50s ' test/test-per-cc-obj.c
-./src/pluto --notile --noparallel --per-cc-obj test/test-per-cc-obj.c -o test_tmp_out.pluto.c | FileCheck --check-prefix CC-OBJ-CHECK test/test-per-cc-obj.c
+./src/pluto --notile --noparallel --per-cc-obj @top_srcdir@/test/test-per-cc-obj.c -o test_tmp_out.pluto.c | FileCheck --check-prefix CC-OBJ-CHECK @top_srcdir@/test/test-per-cc-obj.c
 check_ret_val_emit_status
 
 # Test typed fusion with dfp. These cases are executed only when glpk or gurobi
 # is enabled. Either of these solvers is required by the dfp framework.
-TESTS="test/dfp/typed-fuse-1.c\
-       test/dfp/typed-fuse-2.c\
-       test/dfp/typed-fuse-3.c\
+TESTS="@top_srcdir@/test/dfp/typed-fuse-1.c\
+       @top_srcdir@/test/dfp/typed-fuse-2.c\
+       @top_srcdir@/test/dfp/typed-fuse-3.c\
        "
 if grep -q -e "#define GLPK 1" -e "#define GUROBI 1" config.h; then
    for file in $TESTS; do
@@ -90,8 +90,8 @@ if grep -q -e "#define GLPK 1" -e "#define GUROBI 1" config.h; then
 fi
 
 TESTS_TILE_PARALLEL="\
-  test/dep-1,1.c \
-  test/diamond-tile-example.c
+  @top_srcdir@/test/dep-1,1.c \
+  @top_srcdir@/test/diamond-tile-example.c
   "
 echo -e "\nTest without pet frontend but with tiling / parallelization"
 echo "============================================================"
@@ -102,7 +102,7 @@ for file in $TESTS_TILE_PARALLEL; do
 done
 
 TEST_MORE_INTRA_TILE_OPT="\
-    test/intratileopt5.c
+    @top_srcdir@/test/intratileopt5.c
 "
 for file in $TEST_MORE_INTRA_TILE_OPT; do
     printf '%-50s ' "$file with --maxfuse"
@@ -114,10 +114,10 @@ for file in $TEST_MORE_INTRA_TILE_OPT; do
 done
 
 TESTS_PET="\
-  test/heat-2d.c \
-  test/heat-3d.c \
-  test/jacobi-3d-25pt.c \
-  test/matmul.c \
+  @top_srcdir@/test/heat-2d.c \
+  @top_srcdir@/test/heat-3d.c \
+  @top_srcdir@/test/jacobi-3d-25pt.c \
+  @top_srcdir@/test/matmul.c \
   "
 # Tests with pet frontend with tiling and parallelization disabled.
 echo -e "\nTest with pet frontend with no tiling / parallelization"
@@ -140,9 +140,9 @@ done
 echo -e "\nTest ISS"
 echo "========"
 TESTS_ISS="\
-  test/jacobi-2d-periodic.c \
-  test/multi-stmt-periodic.c \
-  test/heat-2dp.c \
+  @top_srcdir@/test/jacobi-2d-periodic.c \
+  @top_srcdir@/test/multi-stmt-periodic.c \
+  @top_srcdir@/test/heat-2dp.c \
   "
 for file in $TESTS_ISS; do
     printf '%-50s ' $file
@@ -152,10 +152,10 @@ done
 
 # Test libpluto interface.
 echo -e "\nTest libpluto interface"
-file=test/test_libpluto.c
+file=@top_srcdir@/test/test_libpluto.c
 echo "============================="
 printf '%-50s ' test_libpluto
-./test_libpluto | FileCheck test/test_libpluto.c
+./test_libpluto | FileCheck @top_srcdir@/test/test_libpluto.c
 check_ret_val_emit_status
 
 # Unit tests
@@ -164,7 +164,7 @@ echo "==============="
 printf '%-50s ' unit_tests
 # Filter out all "// " comments from unit_tests.in when sending input to
 # 'unit_tests'.
-cat test/unit_tests.in | grep -v "^// " | ./unit_tests | FileCheck test/unit_tests.in
+cat @top_srcdir@/test/unit_tests.in | grep -v "^// " | ./unit_tests | FileCheck @top_srcdir@/test/unit_tests.in
 check_ret_val_emit_status
 
 # TODO: add tests that check the generated code for certain things (like stmt


### PR DESCRIPTION
Makefiles, build scripts and tests currently assume that the build
path and source path are identical. This causes VPATH (out-of-tree)
builds to fail.

Steps to reproduce:
  ```
  $ git clone https://github.com/bondhugula/pluto.git --recursive
  $ cd pluto
  $ ./autogen.sh
  $ cd ..
  $ mkdir pluto-build && cd pluto-build
  $ ../pluto/configure --prefix=...
  ...
  ==========================
  Configuring PipLib
  ==========================
  ../pluto/configure: line 12568: cd: piplib/: No such file or directory
  ../pluto/configure: line 12570: ./configure: No such file or directory

  ==========================
  Configuring Openscop
  ==========================
  ../pluto/configure: line 12581: cd: openscop/: No such file or directory
  ../pluto/configure: line 12582: ./configure: No such file or directory

  ==========================
  Configuring Clan
  ==========================
  ../pluto/configure: line 12593: cd: clan/: No such file or directory
  ../pluto/configure: line 12594: ./configure: No such file or directory
  checking for clan/Makefile... no
  configure: error: configure in clan/ failed
  ```

This patch sets the correct paths for the configuration and
compilation of submodules and fixes the paths in the main test
script. An update of the reference to candl was also necessary, due to
a minor bug in the candle sources preventing VPATH builds for candle
itself for all versions prior to commit a465102.

Tested for in-tree builds (e.g., ./configure ...), VPATH builds with a
relative path to the sources (e.g., ../pluto/configure ...) and VPATH
builds with an absolute path (e.g., /usr/src/pluto/configure ...).

Signed-off-by: Andi Drebes <andi@drebesium.org>