### PR TITLE
Update support for unroll and jam optimizations.

### DIFF
--- a/polycc.sh.in
+++ b/polycc.sh.in
@@ -64,16 +64,6 @@ prefix=`basename $SOURCEFILE .c`
 CLOOGFILE=`basename $OUTFILE`.pluto.cloog
 PLUTOOUT=$OUTFILE
 
-# generate and insert unrolling annotations, run ancc on it,
-# if [ "$UNROLL" == 1 ]; then
-#     $plorc $PLUTOOUT @srcdir@/orio-0.1.0
-# fi
-
-#if [ "$UNROLL" == 1 ]; then
-    #$plann $PLUTOOUT @srcdir@/annotations
-#fi
-
-
 # put the original skeleton around the transformed code
 $inscop $SOURCEFILE $OUTFILE $OUTFILE
 

--- a/polycc.sh.in
+++ b/polycc.sh.in
@@ -65,9 +65,9 @@ CLOOGFILE=`basename $OUTFILE`.pluto.cloog
 PLUTOOUT=$OUTFILE
 
 # generate and insert unrolling annotations, run ancc on it,
-if [ "$UNROLL" == 1 ]; then
-    $plorc $PLUTOOUT @srcdir@/orio-0.1.0
-fi
+# if [ "$UNROLL" == 1 ]; then
+#     $plorc $PLUTOOUT @srcdir@/orio-0.1.0
+# fi
 
 #if [ "$UNROLL" == 1 ]; then
     #$plann $PLUTOOUT @srcdir@/annotations

--- a/src/ast_transform.c
+++ b/src/ast_transform.c
@@ -186,7 +186,7 @@ void pluto_mark_unroll_jam(struct clast_stmt *root, const PlutoProg *prog,
       continue;
     }
     for (unsigned j = 0; j < nloops; j++) {
-      loops[j]->unroll += CLAST_UNROLL_JAM;
+      loops[j]->unroll_type += clast_unroll_and_jam;
       loops[j]->ufactor = ufactor;
     }
     free(stmtids);

--- a/src/ast_transform.c
+++ b/src/ast_transform.c
@@ -136,6 +136,67 @@ void pluto_mark_parallel(struct clast_stmt *root, const PlutoProg *prog,
   pluto_bands_free(pbands, npbands);
 }
 
+/// Marks loops in the cloog clast for unroll jam. Currently it marks all
+/// possible candidates. A way to restrict it must be implemented.
+void pluto_mark_unroll_jam(struct clast_stmt *root, const PlutoProg *prog,
+                           CloogOptions *cloogOptions, unsigned ufactor) {
+
+  PlutoContext *context = prog->context;
+  PlutoOptions *options = context->options;
+  assert(root != NULL);
+  unsigned num_ujloops;
+  Ploop **ujloops = pluto_get_unroll_jam_loops(prog, &num_ujloops);
+  if (num_ujloops == 0) {
+    if (!options->silent) {
+      printf("[pluto-unroll-jam] No unroll jam loop candidates found\n");
+    }
+    return;
+  }
+  IF_DEBUG(printf("Unroll jam candidates \n"));
+  IF_DEBUG(pluto_loops_print(ujloops, num_ujloops));
+
+  for (unsigned i = 0; i < num_ujloops; i++) {
+    char iter[13];
+    sprintf(iter, "t%d", ujloops[i]->depth + 1);
+    unsigned *stmtids =
+        (unsigned *)malloc(ujloops[i]->nstmts * sizeof(unsigned));
+    for (unsigned j = 0; j < ujloops[i]->nstmts; j++) {
+      stmtids[j] = ujloops[i]->stmts[j]->id + 1;
+    }
+
+    struct clast_for **loops;
+    unsigned nloops, nstmts;
+    /* TODO: clast_filter takes an arugument of type int**. However the usage of
+     * this needs to be checked. */
+    int *stmts;
+    ClastFilter filter = {iter, (int *)stmtids, (int)ujloops[i]->nstmts,
+                          subset};
+    clast_filter(root, filter, &loops, (int *)&nloops, &stmts, (int *)&nstmts);
+
+    /* There should be at least one */
+    if (nloops == 0) {
+      /* Sometimes loops may disappear (1) tile size larger than trip count
+       * 2) it's a scalar dimension but can't be determined from the
+       * trans matrix */
+      printf("[pluto] pluto_unroll_jam: WARNING: Unroll-jam poly loop not "
+             "found in AST\n");
+      free(stmtids);
+      free(loops);
+      free(stmts);
+      continue;
+    }
+    for (unsigned j = 0; j < nloops; j++) {
+      loops[j]->unroll += CLAST_UNROLL_JAM;
+      loops[j]->ufactor = ufactor;
+    }
+    free(stmtids);
+    free(loops);
+    free(stmts);
+  }
+
+  pluto_loops_free(ujloops, num_ujloops);
+}
+
 /*
  * Clast-based vector loop marking */
 void pluto_mark_vector(struct clast_stmt *root, const PlutoProg *prog,

--- a/src/ast_transform.h
+++ b/src/ast_transform.h
@@ -9,4 +9,6 @@ void pluto_mark_parallel(struct clast_stmt *root, const PlutoProg *prog,
                          CloogOptions *options);
 void pluto_mark_vector(struct clast_stmt *root, const PlutoProg *prog,
                        CloogOptions *options);
+void pluto_mark_unroll_jam(struct clast_stmt *root, const PlutoProg *prog,
+                           CloogOptions *options, unsigned ufactor);
 #endif // AST_TRANSFORM_H

--- a/src/main.c
+++ b/src/main.c
@@ -679,20 +679,6 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
     }
   }
 
-  if (options->unrolljam) {
-    /* Will generate a .unroll file */
-    /* plann/plorc needs a .params */
-    FILE *paramsFP = fopen(".params", "w");
-    if (paramsFP) {
-      int i;
-      for (i = 0; i < prog->npar; i++) {
-        fprintf(paramsFP, "%s\n", prog->params[i]);
-      }
-      fclose(paramsFP);
-    }
-    pluto_detect_mark_register_tile_loops(prog);
-  }
-
   double t_c = 0.0;
 
   if (!options->pet && !strcmp(srcFileName, "stdin")) {

--- a/src/math_support.c
+++ b/src/math_support.c
@@ -715,3 +715,16 @@ void mpz_set_ull(mpz_t n, unsigned long long ull) {
   /* n += (unsigned int)ull */
   mpz_add_ui(n, n, (unsigned int)ull);
 }
+
+/// Returns true if the two input matrices are equal.
+bool are_pluto_matrices_equal(PlutoMatrix *mat1, PlutoMatrix *mat2) {
+  if ((mat1->nrows != mat2->nrows) || (mat1->ncols != mat2->ncols))
+    return false;
+  for (unsigned i = 0; i < mat1->nrows; i++) {
+    for (unsigned j = 0; j < mat1->ncols; j++) {
+      if (mat1->val[i][j] != mat2->val[i][j])
+        return false;
+    }
+  }
+  return true;
+}

--- a/src/math_support.h
+++ b/src/math_support.h
@@ -21,8 +21,9 @@
 #define _MATH_SUPPORT_H
 
 #include <gmp.h>
-#include <stdio.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 typedef struct plutoContext PlutoContext;
 typedef struct pluto_matrix PlutoMatrix;
@@ -76,6 +77,7 @@ char *pluto_affine_function_sprint(int64_t *func, int ndims, const char **vars);
 
 void pluto_matrix_reverse_rows(PlutoMatrix *mat);
 void pluto_matrix_negate(PlutoMatrix *mat);
+bool are_pluto_matrices_equal(PlutoMatrix *mat1, PlutoMatrix *mat2);
 
 int pluto_vector_is_parallel(PlutoMatrix *mat1, int r1, PlutoMatrix *mat2,
                              int r2);

--- a/src/pluto.h
+++ b/src/pluto.h
@@ -642,6 +642,8 @@ int get_outermost_parallel_loop(const PlutoProg *prog);
 int is_loop_dominated(Ploop *loop1, Ploop *loop2, const PlutoProg *prog);
 Ploop **pluto_get_parallel_loops(const PlutoProg *prog, unsigned *nploops);
 Ploop **pluto_get_all_loops(const PlutoProg *prog, unsigned *num);
+Ploop **pluto_get_unroll_jam_loops(const PlutoProg *prog,
+                                   unsigned *num_ujloops);
 Ploop **pluto_get_dom_parallel_loops(const PlutoProg *prog, unsigned *nploops);
 Band **pluto_get_dom_parallel_bands(PlutoProg *prog, unsigned *nbands,
                                     int **comm_placement_levels);
@@ -652,11 +654,14 @@ void pluto_loops_print(Ploop **loops, int num);
 void pluto_loops_free(Ploop **loops, int nloops);
 int pluto_loop_compar(const void *_l1, const void *_l2);
 Band *pluto_band_alloc(Ploop *loop, int width);
+Band *pluto_band_dup(Band *band);
 void pluto_bands_print(Band **bands, int num);
 void pluto_band_print(const Band *band);
 
 Band **pluto_get_outermost_permutable_bands(PlutoProg *prog, unsigned *ndbands);
 Ploop *pluto_loop_dup(Ploop *l);
+Ploop *pluto_loop_alloc();
+void pluto_loop_free(Ploop *l);
 int pluto_loop_is_parallel(const PlutoProg *prog, Ploop *loop);
 int pluto_loop_is_parallel_for_stmt(const PlutoProg *prog, const Ploop *loop,
                                     const Stmt *stmt);
@@ -674,8 +679,11 @@ Ploop **pluto_get_loops_immediately_inner(Ploop *ploop, const PlutoProg *prog,
 int pluto_intra_tile_optimize(PlutoProg *prog, int is_tiled);
 int pluto_intra_tile_optimize_band(Band *band, int is_tiled, PlutoProg *prog);
 
-int pluto_is_band_innermost(const Band *band, int is_tiled);
-Band **pluto_get_innermost_permutable_bands(PlutoProg *prog, unsigned *ndbands);
+int pluto_is_band_innermost(const Band *band, int is_tiled,
+                            unsigned num_levels_introduced);
+Band **pluto_get_innermost_permutable_bands(const PlutoProg *prog,
+                                            unsigned num_tiled_levels,
+                                            unsigned *ndbands);
 int pluto_loop_is_innermost(const Ploop *loop, const PlutoProg *prog);
 
 PlutoConstraints *pluto_get_transformed_dpoly(const Dep *dep, Stmt *src,

--- a/src/pluto_codegen_if.c
+++ b/src/pluto_codegen_if.c
@@ -301,6 +301,14 @@ int pluto_gen_cloog_code(const PlutoProg *prog, int cloogf, int cloogl,
   if (options->parallel) {
     pluto_mark_parallel(root, prog, cloogOptions);
   }
+  /* Unroll jamming has to be done at the end. We do not want the epilogue to be
+   * marked parallel as there will be very few iterations in it. Properties of
+   * the inner loops that are marked PARALLEL or PARALLEL_VEC will be retained
+   * during unroll jamming. */
+  if (options->unrolljam) {
+    pluto_mark_unroll_jam(root, prog, cloogOptions, options->ufactor);
+    clast_unroll_jam(root);
+  }
   clast_pprint(outfp, root, 0, cloogOptions);
   cloog_clast_free(root);
 

--- a/src/program.h
+++ b/src/program.h
@@ -93,6 +93,7 @@ void pluto_separate_stmts(PlutoProg *prog, Stmt **stmts, int num, int level,
                           int offset);
 
 bool pluto_is_hyperplane_scalar(const Stmt *stmt, int level);
+bool pluto_is_depth_scalar(Ploop *loop, int depth);
 int pluto_stmt_is_member_of(int stmt_id, Stmt **slist, int len);
 PlutoAccess **pluto_get_all_waccs(const PlutoProg *prog, int *num);
 int pluto_stmt_is_subset_of(Stmt **s1, int n1, Stmt **s2, int n2);
@@ -141,6 +142,14 @@ isl_stat isl_map_extract_access_func(__isl_take isl_map *map, void *user);
 
 int read_codegen_context_from_file(PlutoConstraints *codegen_context);
 
+bool is_tile_space_loop(Ploop *loop, const PlutoProg *prog);
+unsigned get_num_invariant_accesses(Ploop *loop);
+unsigned get_num_accesses(Ploop *loop);
+unsigned get_num_unique_accesses_in_stmts(Stmt **stmts, unsigned nstmts,
+                                          const PlutoProg *prog);
+unsigned get_num_invariant_accesses_in_stmts(Stmt **stmts, unsigned nstmts,
+                                             unsigned depth,
+                                             const PlutoProg *prog);
 #if defined(__cplusplus)
 }
 #endif

--- a/src/tile.c
+++ b/src/tile.c
@@ -224,7 +224,9 @@ void pluto_tile(PlutoProg *prog) {
   unsigned nbands, i, j, n_ibands, num_tiled_levels, nloops;
   Band **bands, **ibands;
   bands = pluto_get_outermost_permutable_bands(prog, &nbands);
-  ibands = pluto_get_innermost_permutable_bands(prog, &n_ibands);
+  /* Tiling has not been done yet. Hence num_tiled_levels argument to
+   * pluto_get_innermost_permutable_bands is 0. */
+  ibands = pluto_get_innermost_permutable_bands(prog, 0, &n_ibands);
   PlutoContext *context = prog->context;
   PlutoOptions *options = context->options;
 

--- a/test.sh.in
+++ b/test.sh.in
@@ -169,6 +169,15 @@ check_ret_val_emit_status
 
 # TODO: add tests that check the generated code for certain things (like stmt
 # body source esp. while using --pet).
+# Unroll jam tests. These tests check the generated code.
+echo -e "\nTest Unroll jam"
+echo "===================="
+TESTS_UNROLL_JAM="@top_srcdir@/test/unrolljam.c"
+for file in $TESTS_UNROLL_JAM; do
+    printf '%-50s ' $file
+    ./src/pluto --unrolljam --silent --ufactor=2 $file -o test_temp_out.pluto.c && cat test_temp_out.pluto.c | FileCheck $file
+    check_ret_val_emit_status
+done
 
 cleanup()
 {

--- a/test/unrolljam.c
+++ b/test/unrolljam.c
@@ -1,8 +1,43 @@
-/* pluto start (n) */
-for (i = 0; i < n; i++) {
-  for (j = 0; j < n; j++) {
-    a[i][j] = b[i][j] + 1;
-  }
-}
-
-/* pluto end */
+// CHECK: for (t4=32*t1;t4<=(min(M-1,32*t1+31))-1;t4+=2) {
+// CHECK:   for (t5=32*t3;t5<=(min(K-1,32*t3+31))-1;t5+=2) {
+// CHECK:     lbv=32*t2;
+// CHECK:     ubv=min(N-1,32*t2+31);
+// CHECK:     #pragma ivdep
+// CHECK:     #pragma vector always
+// CHECK:     for (t6=lbv;t6<=ubv;t6++) {
+// CHECK:       S1(t1,t2,t3,t4,t6,t5);
+// CHECK:       S1(t1,t2,t3,(t4+1),t6,t5);
+// CHECK:       S1(t1,t2,t3,t4,t6,(t5+1));
+// CHECK:       S1(t1,t2,t3,(t4+1),t6,(t5+1));
+// CHECK:     }
+// CHECK:   }
+// CHECK:   for (;t5<=min(K-1,32*t3+31);t5++) {
+// CHECK:     lbv=32*t2;
+// CHECK:     ubv=min(N-1,32*t2+31);
+// CHECK:     #pragma ivdep
+// CHECK:     #pragma vector always
+// CHECK:     for (t6=lbv;t6<=ubv;t6++) {
+// CHECK:       S1(t1,t2,t3,t4,t6,t5);
+// CHECK:       S1(t1,t2,t3,(t4+1),t6,t5);
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+// CHECK: for (;t4<=min(M-1,32*t1+31);t4++) {
+// CHECK:   for (t5=32*t3;t5<=min(K-1,32*t3+31);t5++) {
+// CHECK:     lbv=32*t2;
+// CHECK:     ubv=min(N-1,32*t2+31);
+// CHECK:     #pragma ivdep
+// CHECK:     #pragma vector always
+// CHECK:     for (t6=lbv;t6<=ubv;t6++) {
+// CHECK:       S1(t1,t2,t3,t4,t6,t5);
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+/* Checks for multi-loop unroll jam after intra tile optimize. The i and k loops
+ * are unroll and jammed by a factor of 2. */
+#pragma scop
+for (i = 0; i < M; i++)
+  for (j = 0; j < N; j++)
+    for (k = 0; k < K; k++)
+      C[i][j] = C[i][j] + A[i][k] * B[k][j];
+#pragma endscop


### PR DESCRIPTION
Mark multiple intra-tile loops in the innermost permutable band for unroll jam
only if:
        - the loop has temporal reuse,
        - the loop is not the innermost, and
        - the number of distinct accesses in the innermost loop does not
          increase beyond a threshold. Currently the threshold is set at 32,
          which was obtained by experiments.
The default unroll factor is 8. This was also determined by experiments on
16 core Intel Skylake SP machine.

The loops marked for unroll jam are then unroll jammed by ClooG.