### PR TITLE
Improve intra-tile optimization heuristics

### DIFF
--- a/src/pluto.h
+++ b/src/pluto.h
@@ -676,8 +676,8 @@ Ploop **pluto_get_loops_under(Stmt **stmts, unsigned nstmts, unsigned depth,
                               const PlutoProg *prog, unsigned *num);
 Ploop **pluto_get_loops_immediately_inner(Ploop *ploop, const PlutoProg *prog,
                                           unsigned *num);
-int pluto_intra_tile_optimize(PlutoProg *prog, int is_tiled);
-int pluto_intra_tile_optimize_band(Band *band, int is_tiled, PlutoProg *prog);
+bool pluto_intra_tile_optimize(PlutoProg *prog, int is_tiled);
+bool pluto_intra_tile_optimize_band(Band *band, int is_tiled, PlutoProg *prog);
 
 int pluto_is_band_innermost(const Band *band, int is_tiled,
                             unsigned num_levels_introduced);

--- a/src/post_transform.c
+++ b/src/post_transform.c
@@ -324,7 +324,7 @@ Band **fuse_per_stmt_bands(Band **per_stmt_bands, unsigned nbands,
                            PlutoContext *context) {
 
   if (nbands == 0) {
-    num_fused_bands = 0;
+    *num_fused_bands = 0;
     return NULL;
   }
   /* Band map is a map that maps each band to a band identifier. All bands that
@@ -462,10 +462,10 @@ bool pluto_intra_tile_optimize_band(Band *band, int num_tiled_levels,
   /* TODO: We need an early bailout condition here. If the number of statements
    * in the band is 1 or the loop nest is not tiled, then we can skip the
    * procedure to find inner most bands corresponding to the input band. */
-  unsigned nstmt_bands = 0;
+  unsigned nstmt_bands;
   Band **per_stmt_bands = get_per_stmt_band(band, &nstmt_bands);
 
-  unsigned num_fused_bands = 0;
+  unsigned num_fused_bands;
   Band **ibands =
       fuse_per_stmt_bands(per_stmt_bands, nstmt_bands, num_tiled_levels,
                           &num_fused_bands, prog->context);
@@ -476,7 +476,7 @@ bool pluto_intra_tile_optimize_band(Band *band, int num_tiled_levels,
   PlutoContext *context = prog->context;
   PlutoOptions *options = context->options;
   if (options->debug) {
-    printf("Bands for intra tile optimiztion \n");
+    printf("Bands for intra tile optimization \n");
     pluto_bands_print(ibands, num_fused_bands);
   }
 
@@ -500,12 +500,12 @@ bool pluto_intra_tile_optimize_band(Band *band, int num_tiled_levels,
        * same. */
       unsigned last_level =
           band->loop->depth + (num_tiled_levels + 1) * band->width;
-      bool move_across_scalar_hyperplanes = false;
       /* Move loop across scalar hyperplanes only if the loop nest is tiled. If
        * the loop nest is not tiled, then moving across scalar hyperplanes might
        * not be valid in all cases. */
       /* FIXME: Requires further exploration to find the exact reason for doing
        * this. */
+      bool move_across_scalar_hyperplanes = false;
       if (num_tiled_levels > 0) {
         move_across_scalar_hyperplanes = true;
       }
@@ -520,7 +520,7 @@ bool pluto_intra_tile_optimize_band(Band *band, int num_tiled_levels,
   return retval;
 }
 
-/// This routine is called only when the band is not tiled ?
+/// FIXME:This routine is called only when the band is not tiled ?
 /// is_tiled: is the band tiled.
 bool pluto_intra_tile_optimize(PlutoProg *prog, int is_tiled) {
   unsigned nbands;

--- a/src/tile.c
+++ b/src/tile.c
@@ -308,7 +308,7 @@ void pluto_tile(PlutoProg *prog) {
   }
 
   if (options->intratileopt) {
-    int retval = 0;
+    bool retval = false;
     for (i = 0; i < nbands; i++) {
       retval |=
           pluto_intra_tile_optimize_band(bands[i], num_tiled_levels, prog);

--- a/src/transforms.c
+++ b/src/transforms.c
@@ -147,8 +147,6 @@ void pluto_make_innermost_loop(Ploop *loop, unsigned last_level,
     /* Current level that has to be made the innermost. */
     unsigned current_level = loop->depth;
     for (unsigned d = loop->depth + 1; d < last_depth; d++) {
-      if (pluto_is_hyperplane_scalar(stmt, d))
-        continue;
       pluto_stmt_loop_interchange(stmt, current_level, d);
       current_level = d;
     }

--- a/test.sh.in
+++ b/test.sh.in
@@ -105,11 +105,11 @@ TEST_MORE_INTRA_TILE_OPT="\
     @top_srcdir@/test/intratileopt5.c
 "
 for file in $TEST_MORE_INTRA_TILE_OPT; do
-    printf '%-50s ' "$file with --maxfuse"
-    ./src/pluto --maxfuse $file -o test_temp_out.pluto.c | FileCheck --check-prefix CHECK-TILE $file
+    printf '%-50s ' "$file"
+    ./src/pluto $file -o test_temp_out.pluto.c | FileCheck --check-prefix TILE-PARALLEL $file
     check_ret_val_emit_status
-    printf '%-50s ' "$file with --maxfuse --notile"
-    ./src/pluto --maxfuse --notile $file -o test_temp_out.pluto.c | FileCheck --check-prefix CHECK-NOTILE $file
+    printf '%-50s ' "$file with --notile"
+    ./src/pluto --notile $file -o test_temp_out.pluto.c | FileCheck $file
     check_ret_val_emit_status
 done
 


### PR DESCRIPTION
        - In cases where statements in a tiled loop nest are distributed
          in the tile-space, for a given outer permutable band, there can be
          multiple permutable bands in the intra tile-space, each corresponding
          to the set of statements are fused in the inter tile space. Hence
          statements for different innermost permutable bands can have different
          intra-tile permutations. This situation can be seen in 2mm and 3mm
          benchmarks from the PolyBench suite, where different intra-tile
          permutations enhance spatial locality and aid in efficient
          vectorization.
        - In cases where loop nests is partially tiled, bring a parallel loop
          to the innermost level, if it is the best loop according to the
          existing cost function.