### PR TITLE
Enable unroll-and-jam by default

### DIFF
--- a/doc/DOC.txt
+++ b/doc/DOC.txt
@@ -101,8 +101,7 @@ COMMAND-LINE OPTIONS
     guaranteed. Fusion is done across SCCs.
 
     --[no]unrolljam
-    Automatically identify and unroll-jam up to two loops. Not enabled
-    by default.
+    Automatically identify and unroll-jam loops. Enabled by default.
 
     --ufactor=<n>
     Unroll or unroll-jam factor (default is 8). Note that if two loops

--- a/src/main.c
+++ b/src/main.c
@@ -149,7 +149,7 @@ void usage_message(void) {
   fprintf(stdout, "\n   Miscellaneous\n");
   fprintf(stdout, "       --rar                     Consider RAR dependences "
                   "too (disabled by default)\n");
-  fprintf(stdout, "       --[no]unrolljam           Unroll and jam (disabled "
+  fprintf(stdout, "       --[no]unrolljam           Unroll and jam (enabled "
                   "by default)\n");
   fprintf(stdout, "       --ufactor=<factor>        Unroll and jam factor "
                   "(default is 8)\n");
@@ -223,7 +223,6 @@ int main(int argc, char *argv[]) {
     {"parallelize", no_argument, &options->parallel, 1},
     {"innerpar", no_argument, &options->innerpar, 1},
     {"iss", no_argument, &options->iss, 1},
-    {"unrolljam", no_argument, &options->unrolljam, 1},
     {"nounrolljam", no_argument, &options->unrolljam, 0},
     {"bee", no_argument, &options->bee, 1},
     {"ufactor", required_argument, 0, 'u'},

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -855,7 +855,7 @@ PlutoOptions *pluto_options_alloc() {
   options->per_cc_obj = 0;
 
   options->iss = 0;
-  options->unrolljam = 0;
+  options->unrolljam = 1;
 
   /* Unroll/jam factor */
   options->ufactor = 8;


### PR DESCRIPTION
Enable unroll-and-jam optimization by default. The default unroll factor is 8. This optimization can be disabled by the flag `--nounrolljam`.