### PR TITLE
Update to Loop fusion heuristics. Add check to detect stencil dependences in SCCs

### DIFF
--- a/src/ddg.c
+++ b/src/ddg.c
@@ -109,8 +109,8 @@ Graph *get_undirected_graph(const Graph *g) {
   return gU;
 }
 
-/* Floyd-Warshall algorithm to find the transitive closure of a graph */
-void transitive_closure(Graph *g) {
+/// Compute the transitive closure of the graph using Floyd-Warshall algorithm.
+void compute_transitive_closure(Graph *g) {
   int i, j, k;
   for (i = 0; i < g->nVertices; i++) {
     for (j = 0; j < g->nVertices; j++) {
@@ -221,7 +221,9 @@ void dfs_for_scc(Graph *g) {
   free(vCopy);
 }
 
-bool is_adjecent(Graph *g, int i, int j) {
+/// Returns true if vertices i and j are adjacent in the graph g, otherwise
+/// returns false.
+bool is_adjacent(Graph *g, int i, int j) {
   if (g->adj->val[i][j] != 0 || g->adj->val[j][i] != 0) {
     return true;
   }

--- a/src/ddg.h
+++ b/src/ddg.h
@@ -47,13 +47,14 @@ struct scc {
    * when used with SCC based clustering heuristic */
   int fcg_scc_offset;
 
-  /* Set to true if the scc is coloured with current colour else false */
+  /* True if the SCC is coloured with current colour else false. */
   bool is_scc_coloured;
 
-  /* Set to true if there is a parallel hyperplane has already been found for
-   * this scc */
+  /* True if there is a parallel hyperplane has already been found for
+   * this SCC, false otherwise. */
   bool has_parallel_hyperplane;
-  /* Set to true if the scc has stencil dependence pattern. */
+
+  /* True if the SCC has stencil dependence pattern, false otherwise. */
   bool is_scc_stencil;
 };
 typedef struct scc Scc;
@@ -98,10 +99,10 @@ Graph *graph_transpose(Graph *g);
 void dfs(Graph *g);
 void dfs_for_scc(Graph *g);
 void dfs_vertex(Graph *g, Vertex *v, int *time);
-void transitive_closure(Graph *g);
+void compute_transitive_closure(Graph *g);
 Vertex *ddg_get_vertex_by_id(Graph *g, int id);
 
-bool is_adjecent(Graph *, int, int);
+bool is_adjacent(Graph *, int, int);
 int *get_ssc_topological_order(Graph *ddg);
 void compute_scc_vertices(Graph *ddg);
 void print_scc_vertices(int scc_id, Graph *g);

--- a/src/ddg.h
+++ b/src/ddg.h
@@ -53,6 +53,8 @@ struct scc {
   /* Set to true if there is a parallel hyperplane has already been found for
    * this scc */
   bool has_parallel_hyperplane;
+  /* Set to true if the scc has stencil dependence pattern. */
+  bool is_scc_stencil;
 };
 typedef struct scc Scc;
 
@@ -96,6 +98,7 @@ Graph *graph_transpose(Graph *g);
 void dfs(Graph *g);
 void dfs_for_scc(Graph *g);
 void dfs_vertex(Graph *g, Vertex *v, int *time);
+void transitive_closure(Graph *g);
 Vertex *ddg_get_vertex_by_id(Graph *g, int id);
 
 bool is_adjecent(Graph *, int, int);

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -1726,14 +1726,19 @@ int pluto_auto_transform(PlutoProg *prog) {
 
     nVertices = 0;
     if (options->scc_cluster) {
-      for (int i = 0; i < ddg->num_sccs; i++) {
-        ddg->sccs[i].fcg_scc_offset = nVertices;
+      for (unsigned i = 0; i < ddg->num_sccs; i++) {
+        if (ddg->sccs[i].max_dim > 0) {
+          ddg->sccs[i].fcg_scc_offset = nVertices;
+        }
         ddg->sccs[i].is_scc_coloured = false;
         nVertices += ddg->sccs[i].max_dim;
+        ddg->sccs[i].is_scc_stencil = false;
       }
     } else {
-      for (int i = 0; i < nstmts; i++) {
-        ddg->vertices[i].fcg_stmt_offset = nVertices;
+      for (unsigned i = 0; i < nstmts; i++) {
+        if (stmts[i]->dim > 0) {
+          ddg->vertices[i].fcg_stmt_offset = nVertices;
+        }
         nVertices += stmts[i]->dim_orig;
       }
     }
@@ -1746,8 +1751,10 @@ int pluto_auto_transform(PlutoProg *prog) {
     PlutoConstraints *permutecst = get_permutability_constraints(prog);
     IF_DEBUG(pluto_constraints_cplex_print(stdout, permutecst););
 
-    /* Yet to start colouring hence the current_colour can be either 0 or 1 */
-    prog->fcg = build_fusion_conflict_graph(prog, colour, nVertices, 0);
+    /* The current_colour parameter has to be 1. This is the indicate that
+     * colouring has to start from first level. Internally this is also used to
+     * introduce must distribute edges in the fusion conflict graph. */
+    prog->fcg = build_fusion_conflict_graph(prog, colour, nVertices, 1);
 
     fcg = prog->fcg;
     fcg->num_coloured_vertices = 0;

--- a/src/pluto.c
+++ b/src/pluto.c
@@ -1326,94 +1326,6 @@ void denormalize_domains(PlutoProg *prog) {
   }
 }
 
-/*
- * Finds domain face that allows concurrent start (for diamond tiling)
- * FIXME: iteration space boundaries are assumed to be corresponding to
- * rectangular ones
- *
- * Returns: matrix with row i being the concurrent start face for Stmt i
- */
-PlutoMatrix *get_face_with_concurrent_start(PlutoProg *prog, Band *band) {
-  PlutoConstraints *bcst;
-  int j, nz, nvar, npar;
-  PlutoMatrix *conc_start_faces;
-  PlutoContext *context = prog->context;
-
-  IF_DEBUG(printf("[pluto] get_face_with_concurrent_start for band\n\t"););
-  IF_DEBUG(pluto_band_print(band););
-
-  npar = prog->npar;
-  nvar = prog->nvar;
-
-  PlutoConstraints *fcst = get_feautrier_schedule_constraints(
-      prog, band->loop->stmts, band->loop->nstmts);
-
-  bcst = get_coeff_bounding_constraints(prog);
-  pluto_constraints_add(fcst, bcst);
-  pluto_constraints_free(bcst);
-
-  int64_t *sol = pluto_prog_constraints_lexmin(fcst, prog);
-  pluto_constraints_free(fcst);
-
-  if (!sol) {
-    IF_DEBUG(printf("[pluto] get_face_with_concurrent_start: no valid 1-d "
-                    "schedules \n"););
-    return NULL;
-  }
-
-  conc_start_faces =
-      pluto_matrix_alloc(band->loop->nstmts, nvar + npar + 1, context);
-  pluto_matrix_set(conc_start_faces, 0);
-
-  for (int s = 0, _s = 0; s < prog->nstmts; s++) {
-    if (!pluto_stmt_is_member_of(s, band->loop->stmts, band->loop->nstmts))
-      continue;
-    assert(_s <= (int)band->loop->nstmts - 1);
-    for (j = 0; j < nvar; j++) {
-      conc_start_faces->val[_s][j] = sol[npar + 1 + s * (nvar + 1) + j];
-    }
-    conc_start_faces->val[_s][nvar + npar] =
-        sol[npar + 1 + s * (nvar + 1) + nvar];
-    _s++;
-  }
-  free(sol);
-
-  IF_DEBUG(printf("[pluto] get_face_with_concurrent_start: 1-d schedules\n"););
-  for (unsigned s = 0; s < band->loop->nstmts; s++) {
-    IF_DEBUG(printf("\tf(S%d) = ", band->loop->stmts[s]->id + 1););
-    IF_DEBUG(pluto_affine_function_print(
-                 stdout, conc_start_faces->val[s], nvar + npar,
-                 (const char **)band->loop->stmts[s]->domain->names););
-    IF_DEBUG(printf("\n"););
-  }
-
-  /* 1-d schedule should be parallel to an iteration space boundary
-   * FIXME: assuming canonical boundaries */
-  unsigned s;
-  for (s = 0; s < band->loop->nstmts; s++) {
-    nz = 0;
-    for (j = 0; j < nvar; j++) {
-      if (conc_start_faces->val[s][j])
-        nz++;
-    }
-    if (nz != 1)
-      break;
-  }
-
-  if (s < band->loop->nstmts) {
-    pluto_matrix_free(conc_start_faces);
-    IF_DEBUG(printf("[pluto] No iteration space faces with concurrent start "
-                    "for all statements\n"););
-    return NULL;
-  }
-
-  IF_DEBUG(
-      printf(
-          "[pluto] faces with concurrent start found for all statements\n"););
-
-  return conc_start_faces;
-}
-
 /// Find hyperplane that completes the cone with previously found hyperplanes
 /// such that the face allowing concurrent start lies within it.
 /// conc_start_faces[i]: concurrent start face for statement $i$
@@ -1650,6 +1562,7 @@ int pluto_auto_transform(PlutoProg *prog) {
   prog->fcg_colour_time = 0.0;
   prog->fcg_dims_scale_time = 0.0;
   prog->fcg_cst_alloc_time = 0.0;
+  prog->stencil_check_time = 0.0;
 
   prog->num_lp_calls = 0;
 
@@ -1707,6 +1620,25 @@ int pluto_auto_transform(PlutoProg *prog) {
     }
   }
 
+  if (options->fuse == kTypedFuse) {
+    /* Mark sccs with stencils to be not distributed. This is accomplished by
+     * setting that an scc already has a parallel hyperplane. This enables
+     * maxfusion for all the statements in the scc. */
+    double tstart = rtclock();
+    for (int i = 0; i < ddg->num_sccs; i++) {
+      if (is_scc_stencil(i, prog)) {
+        ddg->sccs[i].is_scc_stencil = true;
+        ddg->sccs[i].has_parallel_hyperplane = true;
+        IF_DEBUG(printf("Scc %d has stencil dependence pattern\n", i););
+      } else {
+        ddg->sccs[i].is_scc_stencil = false;
+        ddg->sccs[i].has_parallel_hyperplane = false;
+        IF_DEBUG(printf("Scc %d has no stencil dependence patterns\n", i););
+      }
+    }
+    prog->stencil_check_time += rtclock() - tstart;
+  }
+
   /* For diamond tiling */
   bool conc_start_found = false;
 
@@ -1732,7 +1664,6 @@ int pluto_auto_transform(PlutoProg *prog) {
         }
         ddg->sccs[i].is_scc_coloured = false;
         nVertices += ddg->sccs[i].max_dim;
-        ddg->sccs[i].is_scc_stencil = false;
       }
     } else {
       for (unsigned i = 0; i < nstmts; i++) {

--- a/src/pluto.h
+++ b/src/pluto.h
@@ -413,7 +413,7 @@ struct plutoProg {
 
   /* Used to store constraint solving times */
   double mipTime, ilpTime, cst_solve_time, cst_const_time, cst_write_time,
-      scaling_cst_sol_time, skew_time;
+      scaling_cst_sol_time, skew_time, stencil_check_time;
   double fcg_const_time, fcg_colour_time, fcg_dims_scale_time, fcg_update_time,
       fcg_cst_alloc_time;
   long int num_lp_calls;
@@ -505,8 +505,7 @@ void compute_pairwise_permutability(Dep *dep, PlutoProg *prog);
 PlutoConstraints *get_permutability_constraints(PlutoProg *);
 PlutoConstraints *get_scc_permutability_constraints(int, PlutoProg *);
 PlutoConstraints *get_cc_permutability_constraints(int, PlutoProg *);
-PlutoConstraints *get_feautrier_schedule_constraints(PlutoProg *prog, Stmt **,
-                                                     int);
+
 PlutoConstraints **get_stmt_lin_ind_constraints(Stmt *stmt,
                                                 const PlutoProg *prog,
                                                 const PlutoConstraints *currcst,
@@ -552,6 +551,7 @@ int pluto_dynschedule_parallelize(PlutoProg *prog, FILE *sigmafp,
 int pluto_distmem_parallelize(PlutoProg *prog, FILE *sigmafp, FILE *headerfp,
                               FILE *pifp);
 
+bool is_scc_stencil(int scc_id, PlutoProg *prog);
 void ddg_update(Graph *g, PlutoProg *prog);
 void ddg_compute_scc(PlutoProg *prog);
 void ddg_compute_cc(PlutoProg *prog);
@@ -678,6 +678,7 @@ Ploop **pluto_get_loops_immediately_inner(Ploop *ploop, const PlutoProg *prog,
                                           unsigned *num);
 bool pluto_intra_tile_optimize(PlutoProg *prog, int is_tiled);
 bool pluto_intra_tile_optimize_band(Band *band, int is_tiled, PlutoProg *prog);
+PlutoMatrix *get_face_with_concurrent_start(PlutoProg *prog, Band *band);
 
 int pluto_is_band_innermost(const Band *band, int is_tiled,
                             unsigned num_levels_introduced);

--- a/test.sh.in
+++ b/test.sh.in
@@ -95,12 +95,12 @@ TESTS="@top_srcdir@/test/dfp/typed-fuse-1.c\
         ./src/pluto --dfp $file $* -o test_tmp_out.pluto.c | FileCheck $file
         check_ret_val_emit_status
    done
-# Test greedy greedy coloring heuristic in Pluto-lp-dfp
+# Test greedy greedy coloring heuristic and stencil check in Pluto-lp-dfp
    TESTS="test/dfp/fdtd-2d.c\
        "
    for file in $TESTS; do
         printf '%-50s ' "$file with --dfp --clusterscc --lpcolor"
-        ./src/pluto --dfp --lpcolor --clusterscc $file -o test_tmp_out.pluto.c | FileCheck $file
+        ./src/pluto --typedfuse --lpcolor $file -o test_tmp_out.pluto.c | FileCheck $file
         check_ret_val_emit_status
    done
 fi

--- a/test.sh.in
+++ b/test.sh.in
@@ -78,31 +78,31 @@ check_ret_val_emit_status
 # Test typed fusion with dfp. These cases are executed only when glpk or gurobi
 # is enabled. Either of these solvers is required by the dfp framework.
 if grep -q -e "#define GLPK 1" -e "#define GUROBI 1" config.h; then
-TESTS="@top_srcdir@/test/dfp/typed-fuse-1.c\
-       @top_srcdir@/test/dfp/typed-fuse-2.c\
-       @top_srcdir@/test/dfp/typed-fuse-3.c\
-       "
-   for file in $TESTS; do
-   printf '%-50s '  $file
-   ./src/pluto --typedfuse $file $* -o test_tmp_out.pluto.c | FileCheck --check-prefix TYPED-FUSE-CHECK $file
-   check_ret_val_emit_status
-   done
-# Test loop distribution with dfp
-   TESTS="@top_srcdir@/test/dfp/distribution.c\
-       "
-   for file in $TESTS; do
+    TESTS="@top_srcdir@/test/dfp/typed-fuse-1.c\
+        @top_srcdir@/test/dfp/typed-fuse-2.c\
+        @top_srcdir@/test/dfp/typed-fuse-3.c\
+        "
+    for file in $TESTS; do
+        printf '%-50s '  $file
+        ./src/pluto --typedfuse $file $* -o test_tmp_out.pluto.c | FileCheck --check-prefix TYPED-FUSE-CHECK $file
+        check_ret_val_emit_status
+    done
+    # Test loop distribution with dfp
+    TESTS="@top_srcdir@/test/dfp/scalar-distribute.c\
+        "
+    for file in $TESTS; do
         printf '%-50s ' "$file with --dfp"
         ./src/pluto --dfp $file $* -o test_tmp_out.pluto.c | FileCheck $file
         check_ret_val_emit_status
-   done
-# Test greedy greedy coloring heuristic and stencil check in Pluto-lp-dfp
-   TESTS="test/dfp/fdtd-2d.c\
-       "
-   for file in $TESTS; do
+    done
+    # Test greedy greedy coloring heuristic and stencil check in Pluto-lp-dfp
+    TESTS="test/dfp/fdtd-2d.c\
+        "
+    for file in $TESTS; do
         printf '%-50s ' "$file with --dfp --clusterscc --lpcolor"
         ./src/pluto --typedfuse --lpcolor $file -o test_tmp_out.pluto.c | FileCheck $file
         check_ret_val_emit_status
-   done
+    done
 fi
 
 TESTS_TILE_PARALLEL="\

--- a/test.sh.in
+++ b/test.sh.in
@@ -77,15 +77,31 @@ check_ret_val_emit_status
 
 # Test typed fusion with dfp. These cases are executed only when glpk or gurobi
 # is enabled. Either of these solvers is required by the dfp framework.
+if grep -q -e "#define GLPK 1" -e "#define GUROBI 1" config.h; then
 TESTS="@top_srcdir@/test/dfp/typed-fuse-1.c\
        @top_srcdir@/test/dfp/typed-fuse-2.c\
        @top_srcdir@/test/dfp/typed-fuse-3.c\
        "
-if grep -q -e "#define GLPK 1" -e "#define GUROBI 1" config.h; then
    for file in $TESTS; do
    printf '%-50s '  $file
    ./src/pluto --typedfuse $file $* -o test_tmp_out.pluto.c | FileCheck --check-prefix TYPED-FUSE-CHECK $file
    check_ret_val_emit_status
+   done
+# Test loop distribution with dfp
+   TESTS="@top_srcdir@/test/dfp/distribution.c\
+       "
+   for file in $TESTS; do
+        printf '%-50s ' "$file with --dfp"
+        ./src/pluto --dfp $file $* -o test_tmp_out.pluto.c | FileCheck $file
+        check_ret_val_emit_status
+   done
+# Test greedy greedy coloring heuristic in Pluto-lp-dfp
+   TESTS="test/dfp/fdtd-2d.c\
+       "
+   for file in $TESTS; do
+        printf '%-50s ' "$file with --dfp --clusterscc --lpcolor"
+        ./src/pluto --dfp --lpcolor --clusterscc $file -o test_tmp_out.pluto.c | FileCheck $file
+        check_ret_val_emit_status
    done
 fi
 

--- a/test/dfp/fdtd-2d.c
+++ b/test/dfp/fdtd-2d.c
@@ -1,0 +1,46 @@
+// CHECK: T(S1): (t-j, t+j, t)
+// CHECK: loop types (loop, loop, loop)
+// CHECK: T(S2): (t-j, t+j, t+i)
+// CHECK: loop types (loop, loop, loop)
+// CHECK: T(S3): (t-j, t+j, t+i)
+// CHECK: loop types (loop, loop, loop)
+// CHECK: T(S4): (t-j, t+j+1, t+i+1)
+// CHECK: loop types (loop, loop, loop)
+//
+// CHECK: Output written
+
+/* Tests the greedy cost model with clustering in the dfp approach. The greedy
+ * cost model finds the right permutation that enables fusion of all statements,
+ * and thus after skewing, diamond tiling is also enabled. The hyperplane types
+ * are also checked because after skewing, the hyperplane type changes from
+ * scalar to loop at the last level for the first statement. */
+#define tmax 128
+#define nx 2048
+#define ny 2048
+
+double ex[nx][ny + 1];
+double ey[nx + 1][ny];
+double hz[nx][ny];
+
+int main() {
+  int t, i, j;
+
+#pragma scop
+  for (t = 0; t < tmax; t++) {
+    for (j = 0; j < ny; j++)
+      ey[0][j] = t;
+    for (i = 1; i < nx; i++)
+      for (j = 0; j < ny; j++)
+        ey[i][j] = ey[i][j] - 0.5 * (hz[i][j] - hz[i - 1][j]);
+    for (i = 0; i < nx; i++)
+      for (j = 1; j < ny; j++)
+        ex[i][j] = ex[i][j] - 0.5 * (hz[i][j] - hz[i][j - 1]);
+    for (i = 0; i < nx; i++)
+      for (j = 0; j < ny; j++)
+        hz[i][j] = hz[i][j] -
+                   0.7 * (ex[i][j + 1] - ex[i][j] + ey[i + 1][j] - ey[i][j]);
+  }
+#pragma endscop
+
+  return 0;
+}

--- a/test/dfp/scalar-distribute.c
+++ b/test/dfp/scalar-distribute.c
@@ -1,0 +1,18 @@
+/* Tests for loop distribution when there are no dependences between the
+ * statements and one of the statements is a scalar. More precisely, must
+ * distribute edges must not be added and has must distrite routine should not
+ * check for such edges in this case. */
+
+// CHECK: T(S1): (i)
+// CHECK: T(S2): (0)
+// [Pluto] After tiling:
+// CHECK: T(S1): (i)
+// CHECK: T(S2): (0)
+
+#pragma scop
+for (i = 0; i < N; i++) {
+  A[i] = A[i - 1];
+}
+s = B[i];
+#pragma endscop
+


### PR DESCRIPTION
Update loop fusion heuristics in the dfp framework to distribute statements that do not have a path between them in the DDG. Improve auto-transformation times during the clustered FCG construction by reducing the number of constraint allocations. Add routines to detect sccs with stencil dependence patterns and use max-fuse heuristic in such SCCs.