### PR TITLE
Fix ceild and floord definitions

### DIFF
--- a/inscop
+++ b/inscop
@@ -39,8 +39,8 @@ cat .includes > .head
 if ! grep -q "#define ceild(n,d)" __tmp
 	then
 	echo "#include <math.h>" >> .head
-	echo "#define ceild(n,d)  ceil(((double)(n))/((double)(d)))" >> .head
-	echo "#define floord(n,d) floor(((double)(n))/((double)(d)))" >> .head
+	echo "#define ceild(n,d)  (((n)<0) ? -((-(n))/(d)) : ((n)+(d)-1)/(d))" >> .head
+	echo "#define floord(n,d) (((n)<0) ? -((-(n)+(d)-1)/(d)) : (n)/(d))" >> .head
 	echo "#define max(x,y)    ((x) > (y)? (x) : (y))" >> .head
 	echo -e "#define min(x,y)    ((x) < (y)? (x) : (y))\n" >> .head
 fi


### PR DESCRIPTION
Generated code currently uses floating-point division to implement
the ceiling and floor functions. This may lead to incorrect results
if `-ffast-math` is used (in conjuction w/ a `-O` level >0) to compile
such code.

Steps to reproduce:

w/ `-ffast-math`, `(int) floor(((double)(41516))/((double)(107)))` is 387
but 41516/107 = 388.

This patch replaces the current definitions with cloog's, which use
integer division only.