### PR TITLE
Fix test script to return failure status on exit + other

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,11 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: bash
         # Execute the build.
-        run: make -j 16
+        run: |
+          # Build pluto and libpluto test binary.
+          make -j 16 pluto
+          make test_libpluto
+          make unit_tests
 
       - name: Test
         working-directory: ${{github.workspace}}

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ clan-0.6.0/scoplib/scoplib-0.2.0/autoconf/texinfo.tex
 depcomp
 install-sh
 aclocal.m4
+compile_commands.json
 config.h.in
 config.guess
 config.sub

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,10 +55,10 @@ pclean:
 	$(MAKE) -C tool clean
 
 test_libpluto: test/test_libpluto.c
-	libtool --mode=link --tag=CC $(CC) $(CLFAGS) $<  -Llib/.libs/ -I $(top_srcdir)/include $(ISL_INCLUDE) $(ISL_LIBADD) -I openscop/include -lpluto -lgomp -o test_libpluto
+	libtool --mode=link --tag=CC $(CC) $(CFLAGS) $<  -Llib/.libs/ -I $(top_srcdir)/include $(ISL_INCLUDE) $(ISL_LIBADD) -I openscop/include -lpluto -lgomp -o test_libpluto
 
 unit_tests: test/unit_tests.c
-	libtool --mode=link --tag=CC $(CC) $(CLFAGS) $< -Llib/.libs/ -I $(top_srcdir)/include $(ISL_INCLUDE) $(ISL_LIBADD) -I$(top_srcdir)/lib -lpluto -o unit_tests
+	libtool --mode=link --tag=CC $(CC) $(CFLAGS) $< -Llib/.libs/ -I $(top_srcdir)/include $(ISL_INCLUDE) $(ISL_LIBADD) -I$(top_srcdir)/lib -lpluto -o unit_tests
 
 force:
 	true

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,6 @@
 # Copyright (C) 2007 Uday Bondhugula
 #
 #
-
 RM = rm -f
 LN = ln -s
 
@@ -17,14 +16,12 @@ ISL_INCLUDE += -I$(top_srcdir)/isl/include -I$(top_builddir)/isl/include
 ISL_LIBADD += $(top_builddir)/isl/libisl.la
 endif
 
-
 SUBDIRS = piplib polylib $(MAY_ISL) openscop cloog-isl clan candl pet lib tool
 
 ACLOCAL_AMFLAGS = -I m4
 
 dist-hook:
 	rm -rf `find $(distdir)/doc -name CVS`
-
 
 bin_SCRIPTS = polycc plutune getversion.sh
 CLEANFILES: $(bin_SCRIPTS) parsetab.py
@@ -33,7 +30,6 @@ EXTRA_DIST = polycc.sh.in  examples test
 pkginclude_HEADERS = include/pluto/pluto.h include/pluto/matrix.h
 
 polycc: polycc.sh
-	rm -f polycc
 	echo "#! " $(BASH) > polycc
 	cat polycc.sh >> polycc
 	chmod ugo+x polycc

--- a/include/pluto/pluto.h
+++ b/include/pluto/pluto.h
@@ -18,6 +18,7 @@ typedef struct isl_union_map isl_union_map;
 
 #include "isl/ctx.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct pluto_matrix PlutoMatrix;
 

--- a/test.sh.in
+++ b/test.sh.in
@@ -217,8 +217,12 @@ rm -f test_temp_out.pluto.c
 rm -f test_temp_out.pluto.pluto.cloog
 }
 
-echo ===========================
+echo -ne "\n\n==========================="
 echo -e "$num_succ / $(($num_succ + $num_fail)) tests \e[32mPASSED\e[0m"
+if [ $num_fail -gt 0 ]; then
+	echo -e "$num_fail / $(($num_succ + $num_fail)) tests \e[31mFAILED\e[0m"
+fi
 echo ===========================
 
-trap cleanup SIGINT exit
+trap cleanup SIGINT exit $num_fail
+exit $num_fail


### PR DESCRIPTION
Fix test.sh script to return failure status on exit.
Fix build failure for test_libpluto due to a missing include
Fix typo for test_libpluto target in Makefile.am.