### PR TITLE
Fix path specification passed to AC_CHECK_PROG when checking for FileCheck

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,7 @@ AC_ARG_WITH(clang-prefix,
 AM_CONDITIONAL(EXTERNAL_CLANG, test x$external_clang = xtrue)
 
 dnl TODO: check for FileCheck at other places.
-AC_CHECK_PROG(FILECHECK,FileCheck,yes,no,path = "$CLANG_PREFIX/bin:$PATH:/usr/lib64/llvm")
+AC_CHECK_PROG(FILECHECK,FileCheck,yes,no,"$CLANG_PREFIX/bin:$PATH:/usr/lib64/llvm")
 AS_IF([test x"$FILECHECK" != x"yes"], [AC_MSG_ERROR([Please install LLVM FileCheck before configuring.])])
 
 glpk="false"


### PR DESCRIPTION
The set of locations in which `AC_CHECK_PROG` looks for a program is passed to the macro as a colon-separated path specification.

However, in the invocation of `AC_CHECK_PROG` for `FileCheck`, this specification is preceded by an extra `path = `, which causes the first location to be interpreted as `path = $CLANG_PREFIX/bin` rather than `$CLANG_PREFIX/bin`. This causes the check to fail, even if the file `$CLANG_PREFIX/bin/FileCheck` exists and is executable.

Removing the prefix makes the check work as expected.